### PR TITLE
fix: prevent VAD self-triggering and eliminate TTS crackle

### DIFF
--- a/src/features/avatar/pcm-player.ts
+++ b/src/features/avatar/pcm-player.ts
@@ -1,17 +1,39 @@
 const SAMPLE_RATE = 16000;
+const BUFFER_DURATION = 0.1; // 100ms buffer to smooth out chunk arrival jitter
+const BUFFER_SAMPLES = Math.floor(SAMPLE_RATE * BUFFER_DURATION);
 
 export function createPcmPlayer() {
   const ctx = new AudioContext({ sampleRate: SAMPLE_RATE });
   let nextStartTime = 0;
+  let pendingBytes: Uint8Array[] = [];
+  let pendingLength = 0;
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
-  function play(pcm16: Uint8Array) {
-    const samples = pcm16.length / 2;
+  function flush() {
+    flushTimer = null;
+    if (pendingLength === 0) return;
+
+    // Merge pending chunks
+    const merged = new Uint8Array(pendingLength);
+    let offset = 0;
+    for (const chunk of pendingBytes) {
+      merged.set(chunk, offset);
+      offset += chunk.length;
+    }
+    pendingBytes = [];
+    pendingLength = 0;
+
+    // Ensure even byte count (PCM16 = 2 bytes per sample)
+    const usableLength = merged.length & ~1;
+    if (usableLength === 0) return;
+
+    const samples = usableLength / 2;
     const buffer = ctx.createBuffer(1, samples, SAMPLE_RATE);
     const channel = buffer.getChannelData(0);
 
     for (let i = 0; i < samples; i++) {
-      const lo = pcm16[i * 2];
-      const hi = pcm16[i * 2 + 1];
+      const lo = merged[i * 2];
+      const hi = merged[i * 2 + 1];
       const sample = (hi << 8) | lo;
       channel[i] = (sample > 32767 ? sample - 65536 : sample) / 32768;
     }
@@ -21,12 +43,34 @@ export function createPcmPlayer() {
     source.connect(ctx.destination);
 
     const now = ctx.currentTime;
-    if (nextStartTime < now) nextStartTime = now;
+    if (nextStartTime < now) nextStartTime = now + 0.02; // small lead time
     source.start(nextStartTime);
     nextStartTime += buffer.duration;
   }
 
+  function play(pcm16: Uint8Array) {
+    pendingBytes.push(pcm16);
+    pendingLength += pcm16.length;
+
+    // Flush when we have enough samples, or after a short delay
+    if (pendingLength / 2 >= BUFFER_SAMPLES) {
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      flush();
+    } else if (!flushTimer) {
+      flushTimer = setTimeout(flush, 50);
+    }
+  }
+
   function stop() {
+    if (flushTimer) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    pendingBytes = [];
+    pendingLength = 0;
     nextStartTime = 0;
     ctx.close();
   }

--- a/src/features/interview-engine/use-interview-engine.ts
+++ b/src/features/interview-engine/use-interview-engine.ts
@@ -27,7 +27,7 @@ export function useInterviewEngine(config?: InterviewConfig) {
   );
   const [audioLevel, setAudioLevel] = useState(0);
 
-  const gracePeriod = config?.gracePeriod ?? 800;
+  const gracePeriod = config?.gracePeriod ?? 1500;
   const vadThreshold = config?.vadThreshold ?? 0.035;
   const silenceDelay = config?.silenceDelay ?? 2500;
   const minSpeechDuration = config?.minSpeechDuration ?? 1000;
@@ -121,9 +121,9 @@ export function useInterviewEngine(config?: InterviewConfig) {
           mediaRecorder.start(1000);
 
           vadRef.current = createVad({
-            threshold: calibratedThreshold ?? vadThreshold,
+            threshold: calibratedThreshold ?? Math.max(vadThreshold, 0.05),
             silenceDelay,
-            minSpeechDuration,
+            minSpeechDuration: Math.max(minSpeechDuration, 2000),
             onLevel: (rms) => setAudioLevel(rms),
             onSpeechStart: () => {},
             onSpeechEnd: async () => {

--- a/src/features/interview-engine/vad.ts
+++ b/src/features/interview-engine/vad.ts
@@ -74,9 +74,16 @@ export function createVad(options: VadOptions = {}): VadController {
       stopped = false;
       audioContext = new AudioContext();
       const source = audioContext.createMediaStreamSource(stream);
+
+      // High-pass filter to reduce speaker bleed / echo
+      const highpass = audioContext.createBiquadFilter();
+      highpass.type = "highpass";
+      highpass.frequency.value = 200;
+
       analyser = audioContext.createAnalyser();
       analyser.fftSize = 2048;
-      source.connect(analyser);
+      source.connect(highpass);
+      highpass.connect(analyser);
       processFrame();
     },
 


### PR DESCRIPTION
## Summary
- VAD가 면접관 TTS 오디오를 주워서 "답변했다"고 착각하는 문제 수정
- TTS 오디오가 지지직거리는 문제 수정

## Changes
**Issue #5 — VAD 자문자답:**
- Grace period 800ms → 1500ms (TTS 여운이 사라질 시간 확보)
- VAD threshold 0.035 → 0.05 (에코에 덜 민감)
- 최소 발화 시간 1초 → 2초 (짧은 에코 버스트 무시)
- 200Hz 하이패스 필터 추가 (스피커 저주파 블리드 차단)

**Issue #6 — TTS 지지직:**
- 청크 도착 즉시 재생 → 100ms 버퍼링 후 재생
- 작은 청크 병합으로 바이트 경계 분할 방지
- 20ms 리드타임으로 클릭 아티팩트 제거

Closes #5, closes #6

## Test plan
- [ ] 면접관 질문 후 VAD가 즉시 트리거되지 않는지 확인
- [ ] 사용자가 실제로 답변해야만 다음 질문으로 넘어가는지 확인
- [ ] TTS 오디오가 깨끗하게 재생되는지 확인 (지지직 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)