### PR TITLE
fix: update simli face and stabilize 16:9 interviewer view

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ src/
 셋업 → 카운트다운 → [질문 생성 → TTS 발화 → VAD 대기 → Whisper 전사]×N → 세션 저장 → GPT-4o 피드백 → 리포트
 ```
 
+## Simli 영상 비율 정책
+
+- Simli Compose token (`/compose/token`)의 공개 필드에는 `faceId`, `handleSilence`, `maxSessionLength`, `maxIdleTime`, `startFrame`, `audioInputFormat`만 존재하며, `aspectRatio`/`width`/`height` 설정은 제공되지 않습니다.
+- `simli-client@3.0.1`의 `SimliSessionRequest` 타입도 동일하게 비율 설정 필드가 없습니다.
+- 따라서 UltraCoach는 면접관 뷰를 UI에서 `16:9`(`aspect-video`)로 고정하고, 세로 원본에서도 얼굴 잘림을 최소화하기 위해 `object-contain`으로 렌더링합니다.
+- 개발 환경에서 실제 원본 비율은 브라우저 콘솔 로그로 확인할 수 있습니다.
+  - `[ultracoach] simli video_info: raw <w>x<h> ratio <r> (<orientation>)`
+  - `[ultracoach] avatar <video> intrinsic <w>x<h> ...`
+
 ## 스크립트
 
 | 명령어 | 설명 |

--- a/src/app/api/simli-token/route.ts
+++ b/src/app/api/simli-token/route.ts
@@ -4,7 +4,7 @@ import {
 } from "simli-client";
 import { NextResponse } from "next/server";
 
-const FACE_ID = "tmp9i8bbq7c";
+const FACE_ID = "14de6eb1-0ea6-4fde-9522-8552ce691cb6";
 
 export async function POST() {
   try {
@@ -20,6 +20,8 @@ export async function POST() {
       {
         config: {
           faceId: FACE_ID,
+          // Simli compose token currently exposes session controls only.
+          // Aspect ratio / width / height are not available config fields.
           handleSilence: true,
           maxSessionLength: 3600,
           maxIdleTime: 60,

--- a/src/features/avatar/simli-avatar.ts
+++ b/src/features/avatar/simli-avatar.ts
@@ -28,6 +28,30 @@ export async function createSimliAvatar(options: SimliAvatarOptions) {
 
   if (onSpeaking) client.on("speaking", onSpeaking);
   if (onSilent) client.on("silent", onSilent);
+  if (process.env.NODE_ENV === "development") {
+    client.on("video_info", (serialized) => {
+      let parsed: { width?: number; height?: number } | null = null;
+      try {
+        parsed = JSON.parse(serialized) as { width?: number; height?: number };
+      } catch {
+        parsed = null;
+      }
+
+      if (parsed?.width && parsed?.height) {
+        const ratio = parsed.width / parsed.height;
+        const orientation =
+          ratio > 1.05 ? "landscape" : ratio < 0.95 ? "portrait" : "square";
+        console.info(
+          "[ultracoach] simli video_info:",
+          `raw ${parsed.width}x${parsed.height}`,
+          `ratio ${ratio.toFixed(3)} (${orientation})`,
+        );
+        return;
+      }
+
+      console.info("[ultracoach] simli video_info:", serialized);
+    });
+  }
 
   await client.start();
 

--- a/src/features/avatar/use-avatar.ts
+++ b/src/features/avatar/use-avatar.ts
@@ -40,9 +40,10 @@ export function useAvatar() {
         avatarRef.current = avatar;
       } catch (err) {
         console.warn("simli unavailable, using direct audio playback:", err);
+        avatarRef.current = null;
       }
 
-      setIsConnected(true);
+      setIsConnected(avatarRef.current !== null);
     },
     [],
   );

--- a/src/widgets/interview/interview-screen.tsx
+++ b/src/widgets/interview/interview-screen.tsx
@@ -256,6 +256,41 @@ export function InterviewScreen() {
 
   const normalizedLevel = Math.min(audioLevel / 0.1, 1);
 
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+    const video = avatarVideoRef.current;
+    if (!video) return;
+
+    const logDimensions = () => {
+      const iw = video.videoWidth;
+      const ih = video.videoHeight;
+      if (iw === 0 || ih === 0) return;
+      const rect = video.getBoundingClientRect();
+      const ratio = iw / ih;
+      const orientation =
+        ratio > 1.05 ? "landscape" : ratio < 0.95 ? "portrait" : "square";
+      const scaleContain = Math.min(rect.width / iw, rect.height / ih);
+      console.info(
+        "[ultracoach] avatar <video>",
+        `intrinsic ${iw}x${ih}`,
+        `ratio ${ratio.toFixed(3)} (${orientation})`,
+        `display ${Math.round(rect.width)}x${Math.round(rect.height)}px`,
+        `object-contain scale ~${scaleContain.toFixed(2)}x`,
+      );
+    };
+
+    video.addEventListener("loadedmetadata", logDimensions);
+    video.addEventListener("resize", logDimensions);
+    const ro = new ResizeObserver(logDimensions);
+    ro.observe(video);
+
+    return () => {
+      video.removeEventListener("loadedmetadata", logDimensions);
+      video.removeEventListener("resize", logDimensions);
+      ro.disconnect();
+    };
+  }, []);
+
   return (
     <div className="fixed inset-0 z-[100] bg-[#1a1a1a] flex flex-col">
       {/* top bar */}
@@ -288,45 +323,47 @@ export function InterviewScreen() {
       {/* main — speaker view */}
       <div className="flex-1 relative p-2 min-h-0">
         {/* interviewer (avatar) — full */}
-        <div className="relative w-full h-full rounded-lg overflow-hidden bg-[#202020]">
-          <video
-            ref={avatarVideoRef}
-            autoPlay
-            playsInline
-            className="absolute inset-0 w-full h-full object-cover"
-          />
-          <audio ref={avatarAudioRef} autoPlay />
-          {!avatarConnected && (
-            <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
-              <div className="w-24 h-24 rounded-full bg-gradient-to-br from-indigo to-purple flex items-center justify-center text-3xl font-bold text-white">
-                AI
-              </div>
-              {phase === "speaking" && (
-                <div className="flex items-center gap-1">
-                  {[0, 1, 2].map((i) => (
-                    <div
-                      key={i}
-                      className="w-1.5 h-1.5 rounded-full bg-blue animate-pulse"
-                      style={{ animationDelay: `${i * 150}ms` }}
-                    />
-                  ))}
+        <div className="relative w-full h-full rounded-lg overflow-hidden bg-[#e3d9aa] flex items-center justify-center">
+          <div className="relative w-full max-h-full aspect-video rounded-lg overflow-hidden bg-[#e3d9aa]">
+            <video
+              ref={avatarVideoRef}
+              autoPlay
+              playsInline
+              className="absolute inset-0 w-full h-full object-contain bg-[#e3d9aa] scale-[1.01]"
+            />
+            <audio ref={avatarAudioRef} autoPlay />
+            {!avatarConnected && (
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
+                <div className="w-24 h-24 rounded-full bg-gradient-to-br from-indigo to-purple flex items-center justify-center text-3xl font-bold text-white">
+                  AI
                 </div>
+                {phase === "speaking" && (
+                  <div className="flex items-center gap-1">
+                    {[0, 1, 2].map((i) => (
+                      <div
+                        key={i}
+                        className="w-1.5 h-1.5 rounded-full bg-blue animate-pulse"
+                        style={{ animationDelay: `${i * 150}ms` }}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+            <div className="absolute bottom-3 left-3 flex items-center gap-2">
+              <span className="bg-black/60 text-white text-[12px] px-2 py-0.5 rounded">
+                AI 면접관
+              </span>
+              {(phase === "speaking" || avatarIsSpeaking) && (
+                <span className="bg-green/20 text-green text-[11px] px-1.5 py-0.5 rounded">
+                  발언 중
+                </span>
               )}
             </div>
-          )}
-          <div className="absolute bottom-3 left-3 flex items-center gap-2">
-            <span className="bg-black/60 text-white text-[12px] px-2 py-0.5 rounded">
-              AI 면접관
-            </span>
             {(phase === "speaking" || avatarIsSpeaking) && (
-              <span className="bg-green/20 text-green text-[11px] px-1.5 py-0.5 rounded">
-                발언 중
-              </span>
+              <div className="absolute inset-0 rounded-lg ring-2 ring-green/40 pointer-events-none" />
             )}
           </div>
-          {(phase === "speaking" || avatarIsSpeaking) && (
-            <div className="absolute inset-0 rounded-lg ring-2 ring-green/40 pointer-events-none" />
-          )}
         </div>
 
         {/* user (webcam) — PIP top-right */}


### PR DESCRIPTION
## Summary
- switch Simli face configuration and keep interviewer panel fixed at 16:9 while preserving portrait/square sources with contain rendering
- remove visible black edge artifacts by unifying background color and slight scale compensation in the avatar video layer
- improve resilience when Simli fails or hits rate limits by preventing false connected state and documenting current Simli token API aspect-ratio limitations

## Test plan
- [x] run `pnpm dev` and open `/interview`
- [x] verify interviewer panel stays 16:9 and no black side seams are visible
- [x] confirm fallback UI appears instead of black video when Simli session fails/rate limits
- [x] check console logs for stream metadata (`video_info`, `avatar <video>`) and validate source ratio reporting

Closes #10
Closes #11

Made with [Cursor](https://cursor.com)