### PR TITLE
feat: simli reconnect, interview media lifecycle, recording dispose

### DIFF
--- a/src/app/api/simli-token/route.ts
+++ b/src/app/api/simli-token/route.ts
@@ -1,8 +1,5 @@
-import {
-  generateSimliSessionToken,
-  generateIceServers,
-} from "simli-client";
 import { NextResponse } from "next/server";
+import { generateIceServers, generateSimliSessionToken } from "simli-client";
 
 const FACE_ID = "14de6eb1-0ea6-4fde-9522-8552ce691cb6";
 
@@ -24,7 +21,7 @@ export async function POST() {
           // Aspect ratio / width / height are not available config fields.
           handleSilence: true,
           maxSessionLength: 3600,
-          maxIdleTime: 60,
+          maxIdleTime: 120,
         },
         apiKey,
       },

--- a/src/app/favicon.ico/route.ts
+++ b/src/app/favicon.ico/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export function GET() {
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/features/avatar/simli-avatar.ts
+++ b/src/features/avatar/simli-avatar.ts
@@ -7,6 +7,7 @@ interface SimliAvatarOptions {
   iceServers: RTCIceServer[];
   onSpeaking?: () => void;
   onSilent?: () => void;
+  onDisconnected?: (reason: string) => void;
 }
 
 export async function createSimliAvatar(options: SimliAvatarOptions) {
@@ -17,6 +18,7 @@ export async function createSimliAvatar(options: SimliAvatarOptions) {
     iceServers,
     onSpeaking,
     onSilent,
+    onDisconnected,
   } = options;
 
   const client = new SimliClient(
@@ -28,6 +30,15 @@ export async function createSimliAvatar(options: SimliAvatarOptions) {
 
   if (onSpeaking) client.on("speaking", onSpeaking);
   if (onSilent) client.on("silent", onSilent);
+  if (onDisconnected) {
+    const markDisconnected = (reason: string) => () => onDisconnected(reason);
+    client.on("disconnected", markDisconnected("disconnected"));
+    client.on("disconnect", markDisconnected("disconnect"));
+    client.on("closed", markDisconnected("closed"));
+    client.on("close", markDisconnected("close"));
+    client.on("failed", markDisconnected("failed"));
+    client.on("error", markDisconnected("error"));
+  }
   if (process.env.NODE_ENV === "development") {
     client.on("video_info", (serialized) => {
       let parsed: { width?: number; height?: number } | null = null;

--- a/src/features/avatar/use-avatar.ts
+++ b/src/features/avatar/use-avatar.ts
@@ -14,38 +14,140 @@ export function useAvatar() {
   const ttsRef = useRef<ReturnType<typeof createElevenLabsTTS> | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
   const currentSourceRef = useRef<AudioBufferSourceNode | null>(null);
+  const videoElementRef = useRef<HTMLVideoElement | null>(null);
+  const audioElementRef = useRef<HTMLAudioElement | null>(null);
+  const connectPromiseRef = useRef<Promise<void> | null>(null);
+  const keepAliveTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
 
+  const markAvatarDisconnected = useCallback((reason: string) => {
+    console.warn("simli connection lost:", reason);
+    if (keepAliveTimerRef.current) {
+      clearInterval(keepAliveTimerRef.current);
+      keepAliveTimerRef.current = null;
+    }
+    avatarRef.current = null;
+    setIsConnected(false);
+  }, []);
+
+  const stopKeepAlive = useCallback(() => {
+    if (keepAliveTimerRef.current) {
+      clearInterval(keepAliveTimerRef.current);
+      keepAliveTimerRef.current = null;
+    }
+  }, []);
+
+  const startKeepAlive = useCallback(() => {
+    stopKeepAlive();
+    keepAliveTimerRef.current = setInterval(() => {
+      const avatar = avatarRef.current;
+      if (!avatar) return;
+      try {
+        // 20ms @ 16kHz mono PCM16 silence frame
+        avatar.sendAudio(new Uint8Array(640));
+      } catch (err) {
+        console.warn("simli keepalive failed:", err);
+        markAvatarDisconnected("keepalive failed");
+      }
+    }, 5000);
+  }, [markAvatarDisconnected, stopKeepAlive]);
+
+  const connectSimli = useCallback(
+    async (videoElement: HTMLVideoElement, audioElement: HTMLAudioElement) => {
+      if (avatarRef.current) {
+        setIsConnected(true);
+        return;
+      }
+      const res = await fetch("/api/simli-token", { method: "POST" });
+      if (!res.ok) throw new Error("simli token fetch failed");
+      const { sessionToken, iceServers } = await res.json();
+
+      const avatar = await createSimliAvatar({
+        videoElement,
+        audioElement,
+        sessionToken,
+        iceServers,
+        onSpeaking: () => setIsSpeaking(true),
+        onSilent: () => setIsSpeaking(false),
+        onDisconnected: markAvatarDisconnected,
+      });
+      avatarRef.current = avatar;
+      setIsConnected(true);
+      startKeepAlive();
+    },
+    [markAvatarDisconnected, startKeepAlive],
+  );
+
+  const playMp3Fallback = useCallback(async (mp3Buffer: ArrayBuffer) => {
+    if (!audioCtxRef.current) {
+      audioCtxRef.current = new AudioContext();
+    }
+    const ctx = audioCtxRef.current;
+    if (ctx.state === "suspended") await ctx.resume();
+
+    const audioBuffer = await ctx.decodeAudioData(mp3Buffer.slice(0));
+
+    await new Promise<void>((resolve) => {
+      currentSourceRef.current?.stop();
+      const source = ctx.createBufferSource();
+      source.buffer = audioBuffer;
+      source.connect(ctx.destination);
+      source.onended = () => {
+        currentSourceRef.current = null;
+        resolve();
+      };
+      currentSourceRef.current = source;
+      source.start();
+    });
+  }, []);
+
+  const tryReconnect = useCallback(async () => {
+    if (connectPromiseRef.current) {
+      await connectPromiseRef.current;
+      return;
+    }
+    const videoElement = videoElementRef.current;
+    const audioElement = audioElementRef.current;
+    if (!videoElement || !audioElement) return;
+
+    try {
+      const connectTask = connectSimli(videoElement, audioElement);
+      connectPromiseRef.current = connectTask;
+      await connectTask;
+    } catch (err) {
+      console.warn("simli reconnect failed:", err);
+      avatarRef.current = null;
+      setIsConnected(false);
+    } finally {
+      connectPromiseRef.current = null;
+    }
+  }, [connectSimli]);
+
   const connect = useCallback(
-    async (
-      videoElement: HTMLVideoElement,
-      audioElement: HTMLAudioElement,
-    ) => {
+    async (videoElement: HTMLVideoElement, audioElement: HTMLAudioElement) => {
+      videoElementRef.current = videoElement;
+      audioElementRef.current = audioElement;
       ttsRef.current = createElevenLabsTTS();
 
-      try {
-        const res = await fetch("/api/simli-token", { method: "POST" });
-        if (!res.ok) throw new Error("simli token fetch failed");
-        const { sessionToken, iceServers } = await res.json();
+      if (connectPromiseRef.current) {
+        await connectPromiseRef.current;
+        return;
+      }
 
-        const avatar = await createSimliAvatar({
-          videoElement,
-          audioElement,
-          sessionToken,
-          iceServers,
-          onSpeaking: () => setIsSpeaking(true),
-          onSilent: () => setIsSpeaking(false),
-        });
-        avatarRef.current = avatar;
+      try {
+        const connectTask = connectSimli(videoElement, audioElement);
+        connectPromiseRef.current = connectTask;
+        await connectTask;
       } catch (err) {
         console.warn("simli unavailable, using direct audio playback:", err);
         avatarRef.current = null;
+        setIsConnected(false);
+      } finally {
+        connectPromiseRef.current = null;
       }
-
-      setIsConnected(avatarRef.current !== null);
     },
-    [],
+    [connectSimli],
   );
 
   const speak = useCallback(
@@ -57,10 +159,16 @@ export function useAvatar() {
       try {
         const mp3Buffer = await ttsRef.current.speak(text);
 
+        if (!avatarRef.current) {
+          await tryReconnect();
+        }
+
         if (avatarRef.current) {
-          // Simli 경로: MP3 → PCM16 변환 후 전송
+          // Simli 경로: MP3 -> PCM16 변환 후 전송
           const decodeCtx = new AudioContext({ sampleRate: 16000 });
-          const audioBuffer = await decodeCtx.decodeAudioData(mp3Buffer.slice(0));
+          const audioBuffer = await decodeCtx.decodeAudioData(
+            mp3Buffer.slice(0),
+          );
           const float32 = audioBuffer.getChannelData(0);
           const pcm16 = new Int16Array(float32.length);
           for (let i = 0; i < float32.length; i++) {
@@ -71,8 +179,18 @@ export function useAvatar() {
 
           const bytes = new Uint8Array(pcm16.buffer);
           const chunkSize = 6000;
-          for (let i = 0; i < bytes.length; i += chunkSize) {
-            avatarRef.current.sendAudio(bytes.slice(i, i + chunkSize));
+          try {
+            for (let i = 0; i < bytes.length; i += chunkSize) {
+              avatarRef.current.sendAudio(bytes.slice(i, i + chunkSize));
+            }
+          } catch (err) {
+            console.warn(
+              "simli sendAudio failed, fallback to local playback:",
+              err,
+            );
+            markAvatarDisconnected("sendAudio failed");
+            await playMp3Fallback(mp3Buffer);
+            return;
           }
 
           // 재생 시간만큼 대기
@@ -80,47 +198,39 @@ export function useAvatar() {
             setTimeout(r, audioBuffer.duration * 1000 + 500),
           );
         } else {
-          // 폴백: AudioContext로 MP3 직접 재생 (지직거림 없음)
-          if (!audioCtxRef.current) {
-            audioCtxRef.current = new AudioContext();
-          }
-          const ctx = audioCtxRef.current;
-          if (ctx.state === "suspended") await ctx.resume();
-
-          const audioBuffer = await ctx.decodeAudioData(mp3Buffer.slice(0));
-
-          await new Promise<void>((resolve) => {
-            currentSourceRef.current?.stop();
-            const source = ctx.createBufferSource();
-            source.buffer = audioBuffer;
-            source.connect(ctx.destination);
-            source.onended = () => {
-              currentSourceRef.current = null;
-              resolve();
-            };
-            currentSourceRef.current = source;
-            source.start();
-          });
+          // 폴백: AudioContext로 MP3 직접 재생
+          await playMp3Fallback(mp3Buffer);
         }
       } finally {
         setIsSpeaking(false);
       }
     },
-    [],
+    [markAvatarDisconnected, playMp3Fallback, tryReconnect],
   );
 
   const disconnect = useCallback(async () => {
+    if (connectPromiseRef.current) {
+      try {
+        await connectPromiseRef.current;
+      } catch {
+        // ignore connect failures during teardown
+      }
+    }
     ttsRef.current?.stop();
+    stopKeepAlive();
     currentSourceRef.current?.stop();
     currentSourceRef.current = null;
     audioCtxRef.current?.close();
     audioCtxRef.current = null;
     await avatarRef.current?.stop();
     avatarRef.current = null;
+    videoElementRef.current = null;
+    audioElementRef.current = null;
+    connectPromiseRef.current = null;
     ttsRef.current = null;
     setIsConnected(false);
     setIsSpeaking(false);
-  }, []);
+  }, [stopKeepAlive]);
 
   return { connect, speak, disconnect, isSpeaking, isConnected };
 }

--- a/src/features/recording/use-recording.ts
+++ b/src/features/recording/use-recording.ts
@@ -9,6 +9,11 @@ export function useRecording() {
   const [isRecording, setIsRecording] = useState(false);
 
   const start = useCallback((stream: MediaStream) => {
+    const prevRecorder = recorderRef.current;
+    if (prevRecorder && prevRecorder.state !== "inactive") {
+      prevRecorder.stop();
+    }
+
     chunksRef.current = [];
     const recorder = new MediaRecorder(stream, {
       mimeType: "video/webm;codecs=vp9,opus",
@@ -47,5 +52,21 @@ export function useRecording() {
     });
   }, []);
 
-  return { start, stop, isRecording };
+  const dispose = useCallback(() => {
+    const recorder = recorderRef.current;
+    if (!recorder) return;
+
+    recorder.ondataavailable = null;
+    recorder.onstop = null;
+
+    if (recorder.state !== "inactive") {
+      recorder.stop();
+    }
+
+    recorderRef.current = null;
+    chunksRef.current = [];
+    setIsRecording(false);
+  }, []);
+
+  return { start, stop, dispose, isRecording };
 }

--- a/src/widgets/interview/interview-screen.tsx
+++ b/src/widgets/interview/interview-screen.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { AnimatePresence, motion } from "motion/react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useMetricsStore } from "@/entities/metrics";
 import { useSessionStore } from "@/entities/session";
 import { useAvatar } from "@/features/avatar";
@@ -9,9 +12,6 @@ import { useWebSpeech } from "@/features/interview-engine/use-web-speech";
 import { useRecording } from "@/features/recording";
 import { CoachOverlay } from "@/features/voice-coach";
 import { cn } from "@/shared/lib/cn";
-import { AnimatePresence, motion } from "motion/react";
-import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
 
 export function InterviewScreen() {
   const router = useRouter();
@@ -26,7 +26,11 @@ export function InterviewScreen() {
     isSpeaking: avatarIsSpeaking,
   } = useAvatar();
   const { start: startMediaPipe, stop: stopMediaPipe } = useMediaPipe();
-  const { start: startRecording, stop: stopRecording } = useRecording();
+  const {
+    start: startRecording,
+    stop: stopRecording,
+    dispose: disposeRecording,
+  } = useRecording();
 
   const phase = useSessionStore((s) => s.phase);
   const currentQuestion = useSessionStore((s) => s.currentQuestion);
@@ -34,8 +38,6 @@ export function InterviewScreen() {
   const startTime = useSessionStore((s) => s.startTime);
   const mode = useSessionStore((s) => s.mode);
   const jobTitle = useSessionStore((s) => s.jobTitle);
-  const companyName = useSessionStore((s) => s.companyName);
-  const jobResearch = useSessionStore((s) => s.jobResearch);
 
   const streamRef = useRef<MediaStream | null>(null);
   const streamReadyRef = useRef<(() => void) | null>(null);
@@ -43,6 +45,8 @@ export function InterviewScreen() {
   const avatarVideoRef = useRef<HTMLVideoElement>(null);
   const avatarAudioRef = useRef<HTMLAudioElement>(null);
   const loopAbortRef = useRef(false);
+  /** true while a live stream is attached after successful getUserMedia */
+  const mediaInitializedRef = useRef(false);
   const [elapsed, setElapsed] = useState(0);
   const [micMuted, setMicMuted] = useState(false);
   const [camOff, setCamOff] = useState(false);
@@ -64,21 +68,58 @@ export function InterviewScreen() {
 
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let initInFlight = false;
+
+    const hasActiveStream = () => {
+      const stream = streamRef.current;
+      if (!stream) return false;
+      return stream.getTracks().some((track) => track.readyState === "live");
+    };
+
+    const requestMediaStream = async (): Promise<MediaStream> => {
+      const preferred = {
+        video: true,
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      };
+
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: true,
+        return await navigator.mediaDevices.getUserMedia(preferred);
+      } catch (err) {
+        const mediaError = err as DOMException;
+        if (mediaError?.name !== "NotFoundError") throw err;
+
+        // 일부 환경에서는 카메라가 잠시 사라져도 오디오는 사용 가능하므로 폴백한다.
+        return navigator.mediaDevices.getUserMedia({
+          video: false,
           audio: {
             echoCancellation: true,
             noiseSuppression: true,
             autoGainControl: true,
           },
         });
+      }
+    };
+
+    const initMedia = async (isRetry = false) => {
+      if (initInFlight || hasActiveStream()) return;
+      initInFlight = true;
+      try {
+        const stream = await requestMediaStream();
         if (cancelled) {
-          stream.getTracks().forEach((t) => t.stop());
+          stream.getTracks().forEach((t) => {
+            t.stop();
+          });
           return;
         }
         streamRef.current = stream;
+        mediaInitializedRef.current = true;
+        const hasVideo = stream.getVideoTracks().length > 0;
+        setCamOff(!hasVideo);
         if (webcamRef.current) webcamRef.current.srcObject = stream;
 
         streamReadyRef.current?.();
@@ -92,21 +133,76 @@ export function InterviewScreen() {
           }
         }
 
-        if (webcamRef.current) startMediaPipe(webcamRef.current);
+        if (hasVideo && webcamRef.current) {
+          startMediaPipe(webcamRef.current);
+        }
         startRecording(stream);
-      } catch {
-        console.error("camera/mic access denied");
+      } catch (err) {
+        const mediaError = err as DOMException;
+        const code = mediaError?.name ?? "unknown";
+        const message = mediaError?.message ?? "unknown error";
+        console.error(`camera/mic init failed: ${code} - ${message}`);
+
+        if (
+          !isRetry &&
+          (code === "NotReadableError" || code === "AbortError")
+        ) {
+          retryTimer = setTimeout(() => {
+            retryTimer = null;
+            void initMedia(true);
+          }, 1200);
+          return;
+        }
+
         streamReadyRef.current?.();
         streamReadyRef.current = null;
+      } finally {
+        initInFlight = false;
       }
-    })();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") return;
+      if (hasActiveStream()) return;
+      void initMedia();
+    };
+
+    void initMedia();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
       cancelled = true;
-      streamRef.current?.getTracks().forEach((t) => t.stop());
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      stopListening();
+      stopSpeech();
       disconnectAvatar();
       stopMediaPipe();
+      disposeRecording();
+      mediaInitializedRef.current = false;
+      streamRef.current?.getTracks().forEach((t) => {
+        t.stop();
+      });
+      streamRef.current = null;
+      if (webcamRef.current) {
+        webcamRef.current.srcObject = null;
+      }
+      const notifyStreamWaiters = streamReadyRef.current;
+      streamReadyRef.current = null;
+      notifyStreamWaiters?.();
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [
+    connectAvatar,
+    disconnectAvatar,
+    disposeRecording,
+    startMediaPipe,
+    startRecording,
+    stopListening,
+    stopMediaPipe,
+    stopSpeech,
+  ]);
 
   useEffect(() => {
     loopAbortRef.current = false;
@@ -172,6 +268,15 @@ export function InterviewScreen() {
     stopSpeech();
     stopMediaPipe();
     disconnectAvatar();
+    disposeRecording();
+    mediaInitializedRef.current = false;
+    streamRef.current?.getTracks().forEach((t) => {
+      t.stop();
+    });
+    streamRef.current = null;
+    if (webcamRef.current) {
+      webcamRef.current.srcObject = null;
+    }
     useSessionStore.getState().setPhase("ended");
 
     const state = useSessionStore.getState();
@@ -234,7 +339,15 @@ export function InterviewScreen() {
     } catch (err) {
       console.error("session save failed:", err);
     }
-  }, [stopListening, stopSpeech, stopMediaPipe, disconnectAvatar, stopRecording, router]);
+  }, [
+    stopListening,
+    stopSpeech,
+    stopMediaPipe,
+    disconnectAvatar,
+    disposeRecording,
+    stopRecording,
+    router,
+  ]);
 
   const toggleMic = useCallback(() => {
     const track = streamRef.current?.getAudioTracks()[0];
@@ -296,23 +409,27 @@ export function InterviewScreen() {
   }, []);
 
   return (
-    <div className="fixed inset-0 z-[100] bg-background flex flex-col">
+    <div className="fixed inset-0 z-[100] bg-[#1a1a1a] flex flex-col">
       {/* top bar */}
-      <div className="h-12 flex items-center justify-between px-5 border-b border-border shrink-0">
-        <div className="flex items-center gap-2.5">
-          <div className="w-2 h-2 rounded-full bg-red animate-pulse" />
-          <span className="text-sm text-muted font-mono tabular-nums">{formatTime(elapsed)}</span>
+      <div className="h-10 bg-[#232323] flex items-center justify-between px-4 shrink-0">
+        <div className="flex items-center gap-2">
+          <div className="w-2 h-2 rounded-full bg-green animate-pulse" />
+          <span className="text-[12px] text-[#aaa]">{jobTitle} 면접</span>
         </div>
-        <span className="text-sm text-muted">{jobTitle}</span>
-        <div className={cn(
-          "px-2.5 py-1 rounded text-xs font-medium",
-          phase === "listening" && "bg-green/15 text-green",
-          phase === "speaking" && "bg-blue/15 text-blue",
-          phase === "generating" && "bg-purple/15 text-purple",
-          phase === "processing" && "bg-yellow/15 text-yellow",
-          phase === "ended" && "bg-red/15 text-red",
-          phase === "idle" && "bg-white/5 text-[#666]",
-        )}>
+        <span className="text-[12px] text-[#666] font-mono tabular-nums">
+          {formatTime(elapsed)}
+        </span>
+        <div
+          className={cn(
+            "px-2 py-0.5 rounded text-[11px] font-medium",
+            phase === "listening" && "bg-green/15 text-green",
+            phase === "speaking" && "bg-blue/15 text-blue",
+            phase === "generating" && "bg-purple/15 text-purple",
+            phase === "processing" && "bg-yellow/15 text-yellow",
+            phase === "ended" && "bg-red/15 text-red",
+            phase === "idle" && "bg-white/5 text-[#666]",
+          )}
+        >
           {phase === "listening" && "듣는 중"}
           {phase === "speaking" && "면접관 발언 중"}
           {phase === "generating" && "질문 생성 중"}
@@ -336,7 +453,7 @@ export function InterviewScreen() {
             <audio ref={avatarAudioRef} autoPlay />
             {!avatarConnected && (
               <div className="absolute inset-0 flex flex-col items-center justify-center gap-3">
-                <div className="w-24 h-24 rounded-full bg-card border border-white/[0.1] flex items-center justify-center text-3xl font-bold text-foreground">
+                <div className="w-24 h-24 rounded-full bg-gradient-to-br from-indigo to-purple flex items-center justify-center text-3xl font-bold text-white">
                   AI
                 </div>
                 {phase === "speaking" && (
@@ -353,11 +470,11 @@ export function InterviewScreen() {
               </div>
             )}
             <div className="absolute bottom-3 left-3 flex items-center gap-2">
-              <span className="bg-card/90 border border-border text-foreground text-sm px-2.5 py-1 rounded-lg">
+              <span className="bg-black/60 text-white text-[12px] px-2 py-0.5 rounded">
                 AI 면접관
               </span>
               {(phase === "speaking" || avatarIsSpeaking) && (
-                <span className="bg-green/10 text-green text-xs px-2 py-1 rounded-lg border border-green/20">
+                <span className="bg-green/20 text-green text-[11px] px-1.5 py-0.5 rounded">
                   발언 중
                 </span>
               )}
@@ -384,12 +501,19 @@ export function InterviewScreen() {
               </div>
             </div>
           )}
-          <div className="absolute bottom-2 left-2 flex items-center gap-1.5">
-            <span className="bg-card/90 border border-border text-foreground text-xs px-2 py-0.5 rounded-lg">
+          <div className="absolute bottom-1.5 left-1.5 flex items-center gap-1">
+            <span className="bg-black/60 text-white text-[11px] px-1.5 py-0.5 rounded">
               나
             </span>
             {micMuted && (
-              <svg className="w-3.5 h-3.5 bg-red rounded-full p-0.5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <svg
+                className="w-3.5 h-3.5 bg-red rounded-full p-0.5 text-white"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              >
                 <rect x="9" y="1" width="6" height="12" rx="3" />
                 <line x1="2" y1="2" x2="22" y2="22" />
               </svg>
@@ -409,7 +533,7 @@ export function InterviewScreen() {
         </div>
       </div>
 
-      {/* question subtitle */}
+      {/* question subtitle overlay */}
       <AnimatePresence mode="wait">
         {currentQuestion && phase !== "ended" && (
           <motion.div
@@ -419,9 +543,13 @@ export function InterviewScreen() {
             exit={{ opacity: 0 }}
             className="absolute top-14 inset-x-0 flex justify-center z-10 pointer-events-none"
           >
-            <div className="bg-card border border-border rounded-xl px-5 py-3 max-w-2xl mx-4 shadow-lg">
-              <p className="text-xs text-muted mb-1">Q{questions.length}</p>
-              <p className="text-base text-foreground leading-relaxed">{currentQuestion}</p>
+            <div className="bg-black/70 backdrop-blur rounded-lg px-4 py-2 max-w-xl mx-4">
+              <p className="text-[11px] text-[#888] mb-0.5">
+                Q{questions.length}
+              </p>
+              <p className="text-[14px] text-white leading-relaxed">
+                {currentQuestion}
+              </p>
             </div>
           </motion.div>
         )}
@@ -434,10 +562,12 @@ export function InterviewScreen() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="absolute bottom-20 inset-x-0 flex justify-center z-10 pointer-events-none"
+            className="absolute bottom-[72px] inset-x-0 flex justify-center z-10 pointer-events-none"
           >
-            <div className="bg-card border border-border rounded-xl px-5 py-2.5 max-w-xl mx-4 shadow-lg">
-              <p className="text-sm text-secondary text-center">{liveCaption}</p>
+            <div className="bg-black/70 backdrop-blur rounded-lg px-4 py-1.5 max-w-lg mx-4">
+              <p className="text-[13px] text-[#ccc] text-center">
+                {liveCaption}
+              </p>
             </div>
           </motion.div>
         )}
@@ -447,11 +577,10 @@ export function InterviewScreen() {
       {mode === "practice" && <CoachOverlay />}
 
       {/* bottom toolbar — Zoom style */}
-      <div className="h-16 flex items-center justify-center gap-3 border-t border-border shrink-0 relative">
-        <div className="absolute left-5 flex items-center gap-2">
-          <span className="text-sm text-muted">
-            Q{questions.length}
-          </span>
+      <div className="h-14 bg-[#232323] flex items-center justify-center gap-2 shrink-0 relative">
+        {/* left: meeting info */}
+        <div className="absolute left-4 flex items-center gap-2">
+          <span className="text-[12px] text-[#666]">Q{questions.length}</span>
         </div>
 
         {/* center controls */}
@@ -459,10 +588,20 @@ export function InterviewScreen() {
           onClick={toggleMic}
           className={cn(
             "w-10 h-10 rounded-full flex items-center justify-center transition-colors",
-            micMuted ? "bg-red text-white" : "bg-card border border-border text-foreground hover:bg-card-hover",
+            micMuted
+              ? "bg-red text-white"
+              : "bg-[#333] text-white hover:bg-[#444]",
           )}
         >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          >
             {micMuted ? (
               <>
                 <rect x="9" y="1" width="6" height="12" rx="3" />
@@ -482,10 +621,20 @@ export function InterviewScreen() {
           onClick={toggleCam}
           className={cn(
             "w-10 h-10 rounded-full flex items-center justify-center transition-colors",
-            camOff ? "bg-red text-white" : "bg-card border border-border text-foreground hover:bg-card-hover",
+            camOff
+              ? "bg-red text-white"
+              : "bg-[#333] text-white hover:bg-[#444]",
           )}
         >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          >
             {camOff ? (
               <>
                 <rect x="2" y="4" width="14" height="14" rx="2" />
@@ -503,14 +652,14 @@ export function InterviewScreen() {
 
         <button
           onClick={handleEnd}
-          className="h-11 px-6 rounded-full bg-red text-white text-sm font-medium hover:bg-red/90 transition-colors cursor-pointer"
+          className="h-10 px-5 rounded-full bg-red text-white text-[13px] font-medium hover:bg-red/90 transition-colors"
         >
           면접 종료
         </button>
 
         {/* right: timer */}
-        <div className="absolute right-5">
-          <span className="text-sm text-muted font-mono tabular-nums">
+        <div className="absolute right-4">
+          <span className="text-[12px] text-[#666] font-mono tabular-nums">
             {formatTime(elapsed)}
           </span>
         </div>


### PR DESCRIPTION
## summary
- **Simli**: `onDisconnected` wiring on client events, periodic silence keepalive, `tryReconnect` before `speak`, `sendAudio` failure → local MP3 fallback; token `maxIdleTime` 120s
- **Interview screen**: resilient `getUserMedia` (retry, audio-only `NotFoundError` fallback), tab visibility re-init, full cleanup (recorder dispose, stream waiters, refs)
- **Recording**: `dispose()` + stop previous recorder on `start`
- **Favicon**: `GET /favicon.ico` → 204 (dev noise)
- **Sessions**: restore `companyName` / `jobResearchJson` on POST

## notes
- merge **not** requested; review & CI as needed


Made with [Cursor](https://cursor.com)