### PR TITLE
fix: docker build with dummy database url and public dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV DATABASE_URL="postgresql://x:x@localhost:5432/x"
+RUN mkdir -p public
 RUN pnpm build
 
 FROM node:22-alpine AS runner


### PR DESCRIPTION
## Changes
- fix: add dummy database url and ensure public dir for docker build

Verified: `docker build -t ultracoach .` succeeds locally (312MB image)