### PR TITLE
chore: security, perf, db, and test hardening

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,12 @@
   },
   "files": {
     "includes": ["**"],
-    "experimentalScannerIgnores": [".next", "node_modules", "drizzle"]
+    "experimentalScannerIgnores": [
+      ".next",
+      "node_modules",
+      "drizzle",
+      ".claude",
+      ".omc"
+    ]
   }
 }

--- a/drizzle/0003_woozy_captain_britain.sql
+++ b/drizzle/0003_woozy_captain_britain.sql
@@ -1,0 +1,4 @@
+CREATE INDEX "accounts_user_id_idx" ON "accounts" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "metric_snapshots_session_id_idx" ON "metric_snapshots" USING btree ("session_id");--> statement-breakpoint
+CREATE INDEX "questions_session_id_idx" ON "questions" USING btree ("session_id");--> statement-breakpoint
+CREATE INDEX "sessions_user_id_created_at_idx" ON "sessions" USING btree ("user_id","created_at");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,531 @@
+{
+  "id": "8450d7ae-6752-4379-b1df-eaec9a93bcbe",
+  "prevId": "b3784438-6199-45d8-b781-6e09b84af747",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_moments_json": {
+          "name": "key_moments_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_items_json": {
+          "name": "action_items_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_analyses_json": {
+          "name": "question_analyses_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_session_id_sessions_id_fk": {
+          "name": "feedback_session_id_sessions_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feedback_session_id_unique": {
+          "name": "feedback_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.metric_snapshots": {
+      "name": "metric_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshots_json": {
+          "name": "snapshots_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_json": {
+          "name": "events_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "metric_snapshots_session_id_idx": {
+          "name": "metric_snapshots_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "metric_snapshots_session_id_sessions_id_fk": {
+          "name": "metric_snapshots_session_id_sessions_id_fk",
+          "tableFrom": "metric_snapshots",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "questions_session_id_idx": {
+          "name": "questions_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interview_type": {
+          "name": "interview_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "duration_sec": {
+          "name": "duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_score": {
+          "name": "delivery_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_score": {
+          "name": "content_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resume_file_id": {
+          "name": "resume_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_research_json": {
+          "name": "job_research_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_created_at_idx": {
+          "name": "sessions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1774311371218,
       "tag": "0002_mushy_reavers",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777699003062,
+      "tag": "0003_woozy_captain_britain",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "start": "next start",
     "lint": "biome check",
     "format": "biome format --write",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "bench:model-latency": "node scripts/benchmark-question-models.mjs",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
@@ -56,6 +58,7 @@
     "dotenv": "^17.3.1",
     "drizzle-kit": "^0.31.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@22.19.15)(vite@8.0.10(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
 
 packages:
 
@@ -225,8 +228,17 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -875,6 +887,12 @@ packages:
   '@mediapipe/tasks-vision@0.10.32':
     resolution: {integrity: sha512-3tiAZnmKloYnRXYoO3dKltTUGnqeCwzC4lV03uY0vCsE+aveJTyEVQyZHOlQGQNsjK+gRHzkf9q08C99Qm2K0Q==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.1.6':
     resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
 
@@ -941,8 +959,112 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1044,6 +1166,12 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -1073,6 +1201,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/dom-mediacapture-record@1.0.22':
     resolution: {integrity: sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==}
@@ -1115,6 +1246,35 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1124,6 +1284,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -1149,6 +1313,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1173,6 +1341,9 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1362,6 +1533,9 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -1411,12 +1585,25 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
@@ -1773,6 +1960,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
     hasBin: true
@@ -1788,8 +1978,15 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -1797,6 +1994,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.8:
@@ -1890,6 +2091,11 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
@@ -1912,6 +2118,9 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simli-client@3.0.1:
     resolution: {integrity: sha512-4TWccj4pTZqojFNVj8HLaDZ3d44knebmLC9T6GYOz61ttZSoUM/Ogmmyr5SOs/63nc/V52VWvqysCul2x5x5zw==}
 
@@ -1932,6 +2141,12 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -1964,6 +2179,21 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2023,9 +2253,98 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webrtc-adapter@9.0.4:
     resolution: {integrity: sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==}
     engines: {node: '>=6.0.0', npm: '>=3.10.0'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -2129,7 +2448,23 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2533,6 +2868,13 @@ snapshots:
 
   '@mediapipe/tasks-vision@0.10.32': {}
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@16.1.6': {}
 
   '@next/mdx@16.2.1(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.3))':
@@ -2566,7 +2908,62 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
+  '@oxc-project/types@0.127.0': {}
+
   '@panva/hkdf@1.2.1': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2646,6 +3043,16 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.2
 
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -2673,6 +3080,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/dom-mediacapture-record@1.0.22': {}
 
@@ -2712,11 +3121,54 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -2734,6 +3186,8 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@6.2.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -2749,6 +3203,8 @@ snapshots:
   collapse-white-space@2.1.0: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  convert-source-map@2.0.0: {}
 
   cssesc@3.0.0: {}
 
@@ -2834,6 +3290,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  es-module-lexer@2.1.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -2969,9 +3427,15 @@ snapshots:
 
   events@3.3.0: {}
 
+  expect-type@1.3.0: {}
+
   extend@3.0.2: {}
 
   fast-equals@5.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   framer-motion@12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -3499,6 +3963,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  obug@2.1.1: {}
+
   openai@6.26.0(zod@3.25.76):
     optionalDependencies:
       zod: 3.25.76
@@ -3513,7 +3979,11 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -3521,6 +3991,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.13:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -3658,6 +4134,27 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
   rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
@@ -3704,6 +4201,8 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  siginfo@2.0.0: {}
+
   simli-client@3.0.1(@types/dom-mediacapture-record@1.0.22):
     dependencies:
       livekit-client: 2.17.3(@types/dom-mediacapture-record@1.0.22)
@@ -3722,6 +4221,10 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stringify-entities@4.0.4:
     dependencies:
@@ -3746,6 +4249,17 @@ snapshots:
   tapable@2.3.0: {}
 
   tiny-invariant@1.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   trim-lines@3.0.1: {}
 
@@ -3834,9 +4348,55 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite@8.0.10(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.15
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+
+  vitest@4.1.5(@types/node@22.19.15)(vite@8.0.10(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@22.19.15)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - msw
+
   webrtc-adapter@9.0.4:
     dependencies:
       sdp: 3.2.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   zod@3.25.76: {}
 

--- a/src/app/api/next-question/route.ts
+++ b/src/app/api/next-question/route.ts
@@ -1,14 +1,15 @@
-import { auth } from "@/shared/lib/auth";
-import { rateLimit } from "@/shared/lib/rate-limit";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { interviewTypeSchema } from "@/entities/session";
+import { auth } from "@/shared/lib/auth";
 import { getOpenAI, parseJsonResponse } from "@/shared/lib/openai";
+import { rateLimit } from "@/shared/lib/rate-limit";
 
 const checkRate = rateLimit({ windowMs: 60_000, max: 60 });
 
 const requestSchema = z.object({
   jobTitle: z.string().max(200),
-  interviewType: z.string().max(50),
+  interviewType: interviewTypeSchema,
   resumeFileId: z.string().nullable().optional(),
   history: z
     .array(
@@ -232,9 +233,7 @@ export async function POST(request: Request) {
     ];
 
     if (history.length === 0) {
-      parts.push(
-        "\n(첫 만남입니다. 간결하게 인사하고 자기소개를 요청하세요)",
-      );
+      parts.push("\n(첫 만남입니다. 간결하게 인사하고 자기소개를 요청하세요)");
     } else {
       parts.push(`\n대화 이력 (${history.length}회):`);
       for (const entry of history) {

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -3,12 +3,18 @@ import { NextResponse } from "next/server";
 import { db } from "@/shared/db";
 import { users } from "@/shared/db/schema";
 import { auth } from "@/shared/lib/auth";
+import { rateLimit } from "@/shared/lib/rate-limit";
+
+const checkRate = rateLimit({ windowMs: 60_000, max: 20 });
 
 export async function PATCH(request: Request) {
   const session = await auth();
   if (!session?.user?.id) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
+
+  const limited = checkRate(session.user.id, "profile");
+  if (limited) return limited;
 
   const body = await request.json();
   const name = typeof body.name === "string" ? body.name.trim() : null;

--- a/src/app/api/research-job/route.ts
+++ b/src/app/api/research-job/route.ts
@@ -1,15 +1,16 @@
-import { auth } from "@/shared/lib/auth";
-import { rateLimit } from "@/shared/lib/rate-limit";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { interviewTypeSchema } from "@/entities/session";
+import { auth } from "@/shared/lib/auth";
 import { getOpenAI } from "@/shared/lib/openai";
+import { rateLimit } from "@/shared/lib/rate-limit";
 
 const checkRate = rateLimit({ windowMs: 60_000, max: 10 });
 
 const requestSchema = z.object({
   jobTitle: z.string().max(200),
   companyName: z.string().max(100).optional(),
-  interviewType: z.string().max(50),
+  interviewType: interviewTypeSchema,
 });
 
 const researchSchema = z.object({

--- a/src/app/api/sessions/[id]/drill/route.ts
+++ b/src/app/api/sessions/[id]/drill/route.ts
@@ -6,6 +6,9 @@ import { db } from "@/shared/db";
 import { feedback as feedbackTable, sessions } from "@/shared/db/schema";
 import { auth } from "@/shared/lib/auth";
 import { getOpenAI, parseJsonResponse } from "@/shared/lib/openai";
+import { rateLimit } from "@/shared/lib/rate-limit";
+
+const checkRate = rateLimit({ windowMs: 60_000, max: 30 });
 
 const drillRequestSchema = z.object({
   questionId: z.number(),
@@ -35,6 +38,9 @@ export async function POST(
     if (!session?.user?.id) {
       return NextResponse.json({ error: "unauthorized" }, { status: 401 });
     }
+
+    const limited = checkRate(session.user.id, "session-drill");
+    if (limited) return limited;
 
     const [target] = await db
       .select({

--- a/src/app/api/sessions/[id]/feedback/route.ts
+++ b/src/app/api/sessions/[id]/feedback/route.ts
@@ -6,6 +6,9 @@ import { db } from "@/shared/db";
 import { feedback as feedbackTable, sessions } from "@/shared/db/schema";
 import { auth } from "@/shared/lib/auth";
 import { getOpenAI, parseJsonResponse } from "@/shared/lib/openai";
+import { rateLimit } from "@/shared/lib/rate-limit";
+
+const checkRate = rateLimit({ windowMs: 60_000, max: 10 });
 
 const requestSchema = z.object({
   metrics: z.record(z.string(), z.unknown()),
@@ -106,6 +109,9 @@ export async function POST(
     if (!session?.user?.id) {
       return NextResponse.json({ error: "unauthorized" }, { status: 401 });
     }
+
+    const limited = checkRate(session.user.id, "session-feedback");
+    if (limited) return limited;
 
     const [target] = await db
       .select({

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { interviewModeSchema, interviewTypeSchema } from "@/entities/session";
 import { db } from "@/shared/db";
 import {
   metricSnapshots,
@@ -7,6 +8,9 @@ import {
   sessions,
 } from "@/shared/db/schema";
 import { auth } from "@/shared/lib/auth";
+import { rateLimit } from "@/shared/lib/rate-limit";
+
+const checkRate = rateLimit({ windowMs: 60_000, max: 10 });
 
 const metricSnapshotSchema = z.object({
   timestamp: z.number(),
@@ -38,8 +42,8 @@ const metricEventSchema = z.object({
 
 const requestSchema = z.object({
   jobTitle: z.string().max(200),
-  interviewType: z.string().max(50),
-  mode: z.string().max(20),
+  interviewType: interviewTypeSchema,
+  mode: interviewModeSchema,
   durationSec: z.number().int().min(0).max(86400),
   companyName: z.string().max(100).nullable().optional(),
   jobResearchJson: z.record(z.unknown()).nullable().optional(),
@@ -68,6 +72,9 @@ export async function POST(request: Request) {
     if (!session?.user?.id) {
       return NextResponse.json({ error: "unauthorized" }, { status: 401 });
     }
+
+    const limited = checkRate(session.user.id, "sessions");
+    if (limited) return limited;
 
     const body = requestSchema.safeParse(await request.json());
     if (!body.success) {

--- a/src/app/api/simli-token/route.ts
+++ b/src/app/api/simli-token/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@/shared/lib/auth";
-import { rateLimit } from "@/shared/lib/rate-limit";
 import { NextResponse } from "next/server";
 import { generateIceServers, generateSimliSessionToken } from "simli-client";
+import { auth } from "@/shared/lib/auth";
+import { rateLimit } from "@/shared/lib/rate-limit";
 
 const checkRate = rateLimit({ windowMs: 60_000, max: 10 });
 

--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@/shared/lib/auth";
-import { rateLimit } from "@/shared/lib/rate-limit";
 import { NextResponse } from "next/server";
 import { z } from "zod";
+import { auth } from "@/shared/lib/auth";
+import { rateLimit } from "@/shared/lib/rate-limit";
 
 const checkRate = rateLimit({ windowMs: 60_000, max: 60 });
 

--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -1,8 +1,8 @@
-import { auth } from "@/shared/lib/auth";
-import { rateLimit } from "@/shared/lib/rate-limit";
-import { getOpenAI } from "@/shared/lib/openai";
 import { NextResponse } from "next/server";
 import { toFile } from "openai";
+import { auth } from "@/shared/lib/auth";
+import { getOpenAI } from "@/shared/lib/openai";
+import { rateLimit } from "@/shared/lib/rate-limit";
 
 const checkRate = rateLimit({ windowMs: 60_000, max: 10 });
 

--- a/src/app/api/whisper/route.ts
+++ b/src/app/api/whisper/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@/shared/lib/auth";
-import { rateLimit } from "@/shared/lib/rate-limit";
-import { getOpenAI } from "@/shared/lib/openai";
 import { NextResponse } from "next/server";
+import { auth } from "@/shared/lib/auth";
+import { getOpenAI } from "@/shared/lib/openai";
+import { rateLimit } from "@/shared/lib/rate-limit";
 
 const MAX_AUDIO_SIZE = 25 * 1024 * 1024; // 25MB (Whisper API limit)
 const checkRate = rateLimit({ windowMs: 60_000, max: 60 });
@@ -56,7 +56,8 @@ export async function POST(request: Request) {
       file: audio,
       language: "ko",
       temperature: 0,
-      prompt: "면접관과 지원자의 대화입니다. 지원자가 면접 질문에 답변하고 있습니다.",
+      prompt:
+        "면접관과 지원자의 대화입니다. 지원자가 면접 질문에 답변하고 있습니다.",
     });
 
     const text = transcription.text.trim();

--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useSessionStore } from "@/entities/session";
+import { useCallback, useEffect, useState } from "react";
 import { useMetricsStore } from "@/entities/metrics";
+import { useSessionStore } from "@/entities/session";
 import { SetupForm, useJobResearch } from "@/features/setup";
 import { InterviewScreen } from "@/widgets/interview/interview-screen";
-import { useCallback, useEffect, useState } from "react";
 
 type Stage = "setup" | "interview";
 

--- a/src/app/results/[id]/page.tsx
+++ b/src/app/results/[id]/page.tsx
@@ -1,8 +1,8 @@
-import { db } from "@/shared/db";
-import { sessions, feedback } from "@/shared/db/schema";
-import { auth } from "@/shared/lib/auth";
 import { eq } from "drizzle-orm";
 import { notFound, redirect } from "next/navigation";
+import { db } from "@/shared/db";
+import { feedback, sessions } from "@/shared/db/schema";
+import { auth } from "@/shared/lib/auth";
 import { ResultsClient } from "./results-client";
 
 export const dynamic = "force-dynamic";

--- a/src/entities/metrics/index.ts
+++ b/src/entities/metrics/index.ts
@@ -1,3 +1,8 @@
+export {
+  metricEventSchema,
+  metricSnapshotSchema,
+  metricSnapshotsArraySchema,
+} from "./schema";
 export { useMetricsStore } from "./store";
 export type {
   ExpressionMetric,
@@ -7,9 +12,3 @@ export type {
   MetricSnapshot,
   PostureMetric,
 } from "./types";
-
-export {
-  metricEventSchema,
-  metricSnapshotSchema,
-  metricSnapshotsArraySchema,
-} from "./schema";

--- a/src/entities/session/index.ts
+++ b/src/entities/session/index.ts
@@ -10,3 +10,4 @@ export type {
   JobResearch,
   QuestionEntry,
 } from "./types";
+export { interviewModeSchema, interviewTypeSchema } from "./types";

--- a/src/entities/session/types.ts
+++ b/src/entities/session/types.ts
@@ -1,5 +1,14 @@
-export type InterviewMode = "practice" | "real";
-export type InterviewType = "personality" | "technical" | "culture-fit";
+import { z } from "zod";
+
+export const interviewTypeSchema = z.enum([
+  "personality",
+  "technical",
+  "culture-fit",
+]);
+export const interviewModeSchema = z.enum(["practice", "real"]);
+
+export type InterviewType = z.infer<typeof interviewTypeSchema>;
+export type InterviewMode = z.infer<typeof interviewModeSchema>;
 export type EnginePhase =
   | "idle"
   | "generating"

--- a/src/features/analytics/compute-analytics.ts
+++ b/src/features/analytics/compute-analytics.ts
@@ -64,14 +64,18 @@ export function computeAnalytics(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
   );
 
+  const feedbackBySessionId = new Map(
+    feedbackRows.map((r) => [r.sessionId, r] as const),
+  );
+
   return {
     scoreTrends: buildScoreTrends(ascending),
     typeComparison: buildTypeComparison(completed),
     stats: buildStats(sessions, ascending),
     starRadar: buildStarRadar(feedbackRows),
-    fillerHeatmap: buildFillerHeatmap(feedbackRows, allAscending),
-    actionTracker: buildActionTracker(feedbackRows, allAscending),
-    aiRecommendation: buildAiRecommendation(feedbackRows, allAscending),
+    fillerHeatmap: buildFillerHeatmap(feedbackBySessionId, allAscending),
+    actionTracker: buildActionTracker(feedbackBySessionId, allAscending),
+    aiRecommendation: buildAiRecommendation(feedbackBySessionId, allAscending),
   };
 }
 
@@ -294,7 +298,7 @@ function buildStarRadar(feedbackRows: FeedbackRow[]): StarRadarData {
 // --- Filler Heatmap (WEAK-02) ---
 
 function buildFillerHeatmap(
-  feedbackRows: FeedbackRow[],
+  feedbackBySessionId: Map<string, FeedbackRow>,
   sessions: SessionRow[],
 ): FillerHeatmapData {
   const empty: FillerHeatmapData = {
@@ -304,9 +308,6 @@ function buildFillerHeatmap(
     maxFreq: 0,
   };
 
-  // Build a sessionId → session map for ordering and date labels
-  const sessionMap = new Map(sessions.map((s) => [s.id, s]));
-
   // Collect per-session filler data
   const sessionFillerData: Array<{
     sessionId: string;
@@ -315,11 +316,9 @@ function buildFillerHeatmap(
     totalDurationSec: number;
   }> = [];
 
-  // Process feedback rows, maintaining session order (sessions are already sorted ascending)
-  const orderedSessionIds = sessions.map((s) => s.id);
-
-  for (const sessionId of orderedSessionIds) {
-    const row = feedbackRows.find((r) => r.sessionId === sessionId);
+  // Iterate sessions in order; skip ones without feedback
+  for (const session of sessions) {
+    const row = feedbackBySessionId.get(session.id);
     if (!row) continue;
     const parsed = parseFeedback(row.summaryJson);
     if (!parsed.success) continue;
@@ -335,10 +334,9 @@ function buildFillerHeatmap(
     }
 
     if (totalDurationSec > 0) {
-      const s = sessionMap.get(sessionId);
-      const date = s ? new Date(s.createdAt) : new Date();
+      const date = new Date(session.createdAt);
       sessionFillerData.push({
-        sessionId,
+        sessionId: session.id,
         label: `${date.getMonth() + 1}/${date.getDate()}`,
         wordCounts,
         totalDurationSec,
@@ -393,38 +391,31 @@ function buildFillerHeatmap(
 // --- Action Tracker (ACTN-01) ---
 
 function buildActionTracker(
-  feedbackRows: FeedbackRow[],
+  feedbackBySessionId: Map<string, FeedbackRow>,
   sessions: SessionRow[],
 ): ActionTrackerData {
   const empty: ActionTrackerData = { items: [], sessionDate: "" };
 
   // sessions are sorted ascending by createdAt
-  const orderedSessionIds = sessions.map((s) => s.id);
+  const latestSession =
+    sessions.length > 0 ? sessions[sessions.length - 1] : null;
+  const prevSession =
+    sessions.length > 1 ? sessions[sessions.length - 2] : null;
 
-  const latestSessionId =
-    orderedSessionIds.length > 0
-      ? orderedSessionIds[orderedSessionIds.length - 1]
-      : null;
-  const prevSessionId =
-    orderedSessionIds.length > 1
-      ? orderedSessionIds[orderedSessionIds.length - 2]
-      : null;
+  if (!latestSession) return empty;
 
-  if (!latestSessionId) return empty;
-
-  const latestRow = feedbackRows.find((r) => r.sessionId === latestSessionId);
+  const latestRow = feedbackBySessionId.get(latestSession.id);
   if (!latestRow) return empty;
 
   const latestParsed = parseFeedback(latestRow.summaryJson);
   if (!latestParsed.success) return empty;
 
-  const latestSession = sessions.find((s) => s.id === latestSessionId);
-  const sessionDate = latestSession ? latestSession.createdAt : "";
+  const sessionDate = latestSession.createdAt;
 
   // Get previous session action items for delta comparison
   let prevTexts: string[] = [];
-  if (prevSessionId) {
-    const prevRow = feedbackRows.find((r) => r.sessionId === prevSessionId);
+  if (prevSession) {
+    const prevRow = feedbackBySessionId.get(prevSession.id);
     if (prevRow) {
       const prevParsed = parseFeedback(prevRow.summaryJson);
       if (prevParsed.success) {
@@ -470,26 +461,23 @@ function computeWordOverlap(a: string, b: string): number {
 // --- AI Recommendation (ACTN-02) ---
 
 function buildAiRecommendation(
-  feedbackRows: FeedbackRow[],
+  feedbackBySessionId: Map<string, FeedbackRow>,
   sessions: SessionRow[],
 ): AiRecommendationData {
   const empty: AiRecommendationData = { suggestion: "", sessionDate: "" };
 
-  const latestSessionId =
-    sessions.length > 0 ? sessions[sessions.length - 1].id : null;
+  const latestSession =
+    sessions.length > 0 ? sessions[sessions.length - 1] : null;
+  if (!latestSession) return empty;
 
-  if (!latestSessionId) return empty;
-
-  const latestRow = feedbackRows.find((r) => r.sessionId === latestSessionId);
+  const latestRow = feedbackBySessionId.get(latestSession.id);
   if (!latestRow) return empty;
 
   const parsed = parseFeedback(latestRow.summaryJson);
   if (!parsed.success) return empty;
 
-  const latestSession = sessions.find((s) => s.id === latestSessionId);
-
   return {
     suggestion: parsed.data.nextSessionSuggestion,
-    sessionDate: latestSession ? latestSession.createdAt : "",
+    sessionDate: latestSession.createdAt,
   };
 }

--- a/src/features/body-language/use-mediapipe.ts
+++ b/src/features/body-language/use-mediapipe.ts
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMetricsStore, type MetricSnapshot } from "@/entities/metrics";
 import { useCallback, useRef, useState } from "react";
+import { type MetricSnapshot, useMetricsStore } from "@/entities/metrics";
 
 export interface Landmarks {
   face: number[][];

--- a/src/features/drill/drill-prep-screen.tsx
+++ b/src/features/drill/drill-prep-screen.tsx
@@ -38,12 +38,11 @@ export function DrillPrepScreen({
       }
       setMediaReady(true);
     } catch (err) {
-      const e = err as DOMException;
-      if (e.name === "NotAllowedError") {
+      if (err instanceof DOMException && err.name === "NotAllowedError") {
         setPermissionError(
           "카메라와 마이크 접근이 거부되었습니다. 브라우저 설정에서 권한을 허용해 주세요",
         );
-      } else if (e.name === "NotFoundError") {
+      } else if (err instanceof DOMException && err.name === "NotFoundError") {
         setPermissionError("카메라 또는 마이크를 찾을 수 없습니다");
       } else {
         setPermissionError("카메라 연결에 실패했습니다");

--- a/src/features/drill/use-drill-engine.ts
+++ b/src/features/drill/use-drill-engine.ts
@@ -45,7 +45,11 @@ const MAX_ATTEMPTS = 5;
 const GOAL_SCORE = 80;
 const MIN_WORD_COUNT = 1;
 
-export function useDrillEngine({ sessionId, questionId, question }: DrillEngineConfig) {
+export function useDrillEngine({
+  sessionId,
+  questionId,
+  question,
+}: DrillEngineConfig) {
   const [drillPhase, setDrillPhase] = useState<DrillPhase>("prep");
   const [transcript, setTranscript] = useState<string>("");
   const [result, setResult] = useState<DrillResult | null>(null);

--- a/src/features/interview-engine/use-interview-engine.ts
+++ b/src/features/interview-engine/use-interview-engine.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import type { InterviewConfig } from "@/entities/session";
-import { useSessionStore } from "@/entities/session";
 import { useCallback, useRef, useState } from "react";
 import { z } from "zod";
+import type { InterviewConfig } from "@/entities/session";
+import { useSessionStore } from "@/entities/session";
 import { createVad } from "./vad";
 
 const questionResponseSchema = z.object({

--- a/src/features/interview-engine/vad.ts
+++ b/src/features/interview-engine/vad.ts
@@ -57,10 +57,12 @@ export function createVad(options: VadOptions = {}): VadController {
         silenceStart = performance.now();
       }
       const speechDuration = performance.now() - speechStart;
-      const effectiveDelay = speechDuration < 5000
-        ? silenceDelay * 2
-        : silenceDelay;
-      if (silenceStart > 0 && performance.now() - silenceStart > effectiveDelay) {
+      const effectiveDelay =
+        speechDuration < 5000 ? silenceDelay * 2 : silenceDelay;
+      if (
+        silenceStart > 0 &&
+        performance.now() - silenceStart > effectiveDelay
+      ) {
         const duration = speechDuration;
         isSpeaking = false;
         silenceStart = 0;

--- a/src/features/recording/use-recording.ts
+++ b/src/features/recording/use-recording.ts
@@ -37,9 +37,7 @@ export function useRecording() {
       try {
         recorder = new MediaRecorder(recordStream, { mimeType: mt });
         break;
-      } catch {
-        continue;
-      }
+      } catch {}
     }
 
     if (!recorder) {

--- a/src/features/setup/countdown.tsx
+++ b/src/features/setup/countdown.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { cn } from "@/shared/lib/cn";
 import { motion } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/shared/lib/cn";
 
 type StepStatus = "pending" | "loading" | "done" | "error";
 

--- a/src/features/voice-coach/coach-overlay.tsx
+++ b/src/features/voice-coach/coach-overlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { cn } from "@/shared/lib/cn";
 import { AnimatePresence, motion } from "motion/react";
+import { cn } from "@/shared/lib/cn";
 import { useVoiceCoach } from "./use-voice-coach";
 
 const typeColors: Record<string, string> = {

--- a/src/features/voice-coach/use-voice-coach.ts
+++ b/src/features/voice-coach/use-voice-coach.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import type { InterviewConfig } from "@/entities/session";
-import { useMetricsStore } from "@/entities/metrics";
-import { useSessionStore } from "@/entities/session";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useMetricsStore } from "@/entities/metrics";
+import type { InterviewConfig } from "@/entities/session";
+import { useSessionStore } from "@/entities/session";
 import {
   createInterventionEngine,
   type Intervention,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
+import { NextResponse } from "next/server";
 import NextAuth from "next-auth";
 import { authConfig } from "@/shared/lib/auth.config";
-import { NextResponse } from "next/server";
 
 const { auth } = NextAuth(authConfig);
 
@@ -15,5 +15,12 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/api/((?!auth).*)", "/interview", "/history", "/results/:path*"],
+  matcher: [
+    "/api/((?!auth).*)",
+    "/interview",
+    "/history",
+    "/results/:path*",
+    "/dashboard/:path*",
+    "/drill/:path*",
+  ],
 };

--- a/src/shared/db/index.ts
+++ b/src/shared/db/index.ts
@@ -5,6 +5,13 @@ import * as schema from "./schema";
 const url = process.env.DATABASE_URL;
 if (!url) throw new Error("DATABASE_URL is not set");
 
-const client = postgres(url);
+const poolMax = Number(process.env.DATABASE_POOL_MAX ?? 10);
+
+const client = postgres(url, {
+  max: Number.isFinite(poolMax) && poolMax > 0 ? poolMax : 10,
+  idle_timeout: 20,
+  connect_timeout: 10,
+  prepare: false,
+});
 
 export const db = drizzle(client, { schema });

--- a/src/shared/db/schema.ts
+++ b/src/shared/db/schema.ts
@@ -1,5 +1,5 @@
 import {
-  boolean,
+  index,
   integer,
   jsonb,
   pgTable,
@@ -18,57 +18,69 @@ export const users = pgTable("users", {
   image: text("image"),
 });
 
-export const accounts = pgTable("accounts", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  type: text("type").notNull(),
-  provider: text("provider").notNull(),
-  providerAccountId: text("provider_account_id").notNull(),
-  refresh_token: text("refresh_token"),
-  access_token: text("access_token"),
-  expires_at: integer("expires_at"),
-  token_type: text("token_type"),
-  scope: text("scope"),
-  id_token: text("id_token"),
-  session_state: text("session_state"),
-});
+export const accounts = pgTable(
+  "accounts",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    type: text("type").notNull(),
+    provider: text("provider").notNull(),
+    providerAccountId: text("provider_account_id").notNull(),
+    refresh_token: text("refresh_token"),
+    access_token: text("access_token"),
+    expires_at: integer("expires_at"),
+    token_type: text("token_type"),
+    scope: text("scope"),
+    id_token: text("id_token"),
+    session_state: text("session_state"),
+  },
+  (t) => [index("accounts_user_id_idx").on(t.userId)],
+);
 
-export const sessions = pgTable("sessions", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  jobTitle: varchar("job_title", { length: 200 }).notNull(),
-  interviewType: varchar("interview_type", { length: 50 }).notNull(),
-  mode: varchar("mode", { length: 20 }).notNull(),
-  status: varchar("status", { length: 20 }).notNull().default("in_progress"),
-  durationSec: integer("duration_sec"),
-  deliveryScore: integer("delivery_score"),
-  contentScore: integer("content_score"),
-  resumeFileId: text("resume_file_id"),
-  companyName: varchar("company_name", { length: 255 }),
-  jobResearchJson: jsonb("job_research_json"),
-  createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
-});
+export const sessions = pgTable(
+  "sessions",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    jobTitle: varchar("job_title", { length: 200 }).notNull(),
+    interviewType: varchar("interview_type", { length: 50 }).notNull(),
+    mode: varchar("mode", { length: 20 }).notNull(),
+    status: varchar("status", { length: 20 }).notNull().default("in_progress"),
+    durationSec: integer("duration_sec"),
+    deliveryScore: integer("delivery_score"),
+    contentScore: integer("content_score"),
+    resumeFileId: text("resume_file_id"),
+    companyName: varchar("company_name", { length: 255 }),
+    jobResearchJson: jsonb("job_research_json"),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (t) => [index("sessions_user_id_created_at_idx").on(t.userId, t.createdAt)],
+);
 
-export const questions = pgTable("questions", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  sessionId: text("session_id")
-    .notNull()
-    .references(() => sessions.id, { onDelete: "cascade" }),
-  type: varchar("type", { length: 30 }).notNull(),
-  text: text("text").notNull(),
-  answer: text("answer"),
-  order: integer("order").notNull(),
-});
+export const questions = pgTable(
+  "questions",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.id, { onDelete: "cascade" }),
+    type: varchar("type", { length: 30 }).notNull(),
+    text: text("text").notNull(),
+    answer: text("answer"),
+    order: integer("order").notNull(),
+  },
+  (t) => [index("questions_session_id_idx").on(t.sessionId)],
+);
 
 export const feedback = pgTable("feedback", {
   id: text("id")
@@ -84,13 +96,17 @@ export const feedback = pgTable("feedback", {
   questionAnalysesJson: jsonb("question_analyses_json"),
 });
 
-export const metricSnapshots = pgTable("metric_snapshots", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  sessionId: text("session_id")
-    .notNull()
-    .references(() => sessions.id, { onDelete: "cascade" }),
-  snapshotsJson: jsonb("snapshots_json"),
-  eventsJson: jsonb("events_json"),
-});
+export const metricSnapshots = pgTable(
+  "metric_snapshots",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    sessionId: text("session_id")
+      .notNull()
+      .references(() => sessions.id, { onDelete: "cascade" }),
+    snapshotsJson: jsonb("snapshots_json"),
+    eventsJson: jsonb("events_json"),
+  },
+  (t) => [index("metric_snapshots_session_id_idx").on(t.sessionId)],
+);

--- a/src/shared/lib/auth.config.ts
+++ b/src/shared/lib/auth.config.ts
@@ -1,5 +1,5 @@
-import Google from "next-auth/providers/google";
 import type { NextAuthConfig } from "next-auth";
+import Google from "next-auth/providers/google";
 
 export const authConfig: NextAuthConfig = {
   providers: [Google],

--- a/src/shared/lib/auth.ts
+++ b/src/shared/lib/auth.ts
@@ -1,7 +1,7 @@
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import NextAuth from "next-auth";
 import { db } from "../db";
-import { users, accounts } from "../db/schema";
+import { accounts, users } from "../db/schema";
 import { authConfig } from "./auth.config";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/shared/lib/cn";
 import type { ButtonHTMLAttributes } from "react";
+import { cn } from "@/shared/lib/cn";
 
 type Variant = "primary" | "secondary" | "ghost";
 type Size = "sm" | "md" | "lg";

--- a/src/shared/ui/card.tsx
+++ b/src/shared/ui/card.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/shared/lib/cn";
 import type { HTMLAttributes } from "react";
+import { cn } from "@/shared/lib/cn";
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
   glass?: boolean;

--- a/src/shared/ui/chip.tsx
+++ b/src/shared/ui/chip.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/shared/lib/cn";
 import type { HTMLAttributes } from "react";
+import { cn } from "@/shared/lib/cn";
 
 interface ChipProps extends HTMLAttributes<HTMLSpanElement> {
   active?: boolean;

--- a/src/shared/ui/input.tsx
+++ b/src/shared/ui/input.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/shared/lib/cn";
 import type { InputHTMLAttributes } from "react";
+import { cn } from "@/shared/lib/cn";
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;

--- a/src/widgets/drill/drill-screen.tsx
+++ b/src/widgets/drill/drill-screen.tsx
@@ -61,7 +61,11 @@ export function DrillScreen({
 
   // Prep → speaking/listening 전환 시 video element에 stream 연결
   useEffect(() => {
-    if ((drillPhase === "speaking" || drillPhase === "listening") && webcamRef.current && streamRef.current) {
+    if (
+      (drillPhase === "speaking" || drillPhase === "listening") &&
+      webcamRef.current &&
+      streamRef.current
+    ) {
       webcamRef.current.srcObject = streamRef.current;
     }
   }, [drillPhase, streamRef]);

--- a/src/widgets/history/ai-recommendation-card.tsx
+++ b/src/widgets/history/ai-recommendation-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import type { AiRecommendationData } from "@/entities/analytics";
 import { useState } from "react";
+import type { AiRecommendationData } from "@/entities/analytics";
 
 interface AiRecommendationCardProps {
   data: AiRecommendationData;
@@ -12,7 +12,10 @@ function truncate(text: string, maxLength: number): string {
   const truncated = text.slice(0, maxLength);
   // Cut at last space to avoid mid-word truncation
   const lastSpace = truncated.lastIndexOf(" ");
-  return (lastSpace > maxLength * 0.6 ? truncated.slice(0, lastSpace) : truncated) + "...";
+  return (
+    (lastSpace > maxLength * 0.6 ? truncated.slice(0, lastSpace) : truncated) +
+    "..."
+  );
 }
 
 function AiRecommendationCardInner({ data }: AiRecommendationCardProps) {
@@ -45,7 +48,8 @@ function AiRecommendationCardInner({ data }: AiRecommendationCardProps) {
   }
 
   const isLong = data.suggestion.length > 80;
-  const displayText = expanded || !isLong ? data.suggestion : truncate(data.suggestion, 80);
+  const displayText =
+    expanded || !isLong ? data.suggestion : truncate(data.suggestion, 80);
 
   return (
     <div

--- a/src/widgets/history/filler-heatmap.tsx
+++ b/src/widgets/history/filler-heatmap.tsx
@@ -25,23 +25,34 @@ function FillerHeatmapInner({ data }: FillerHeatmapProps) {
   const wordStats = data.words.map((word, wi) => {
     const freqs = data.sessions.map((_, si) => {
       const key = `${si}-${wi}`;
-      return data.cells.find(
-        (c) => c.sessionIdx === si && c.wordIdx === wi,
-      )?.freqPerMin ?? 0;
+      return (
+        data.cells.find((c) => c.sessionIdx === si && c.wordIdx === wi)
+          ?.freqPerMin ?? 0
+      );
     });
     const total = freqs.reduce((a, b) => a + b, 0);
     const avg = total / data.sessions.length;
     const recent = freqs.slice(0, 3);
-    const recentAvg = recent.length > 0
-      ? recent.reduce((a, b) => a + b, 0) / recent.length
-      : 0;
+    const recentAvg =
+      recent.length > 0 ? recent.reduce((a, b) => a + b, 0) / recent.length : 0;
     const older = freqs.slice(3, 6);
-    const olderAvg = older.length > 0
-      ? older.reduce((a, b) => a + b, 0) / older.length
-      : 0;
+    const olderAvg =
+      older.length > 0 ? older.reduce((a, b) => a + b, 0) / older.length : 0;
     const trend =
-      older.length === 0 ? "none" : recentAvg < olderAvg ? "down" : recentAvg > olderAvg ? "up" : "flat";
-    return { word, avg, total, trend, recentFreqs: freqs.slice(0, 5).reverse() };
+      older.length === 0
+        ? "none"
+        : recentAvg < olderAvg
+          ? "down"
+          : recentAvg > olderAvg
+            ? "up"
+            : "flat";
+    return {
+      word,
+      avg,
+      total,
+      trend,
+      recentFreqs: freqs.slice(0, 5).reverse(),
+    };
   });
 
   wordStats.sort((a, b) => b.avg - a.avg);

--- a/src/widgets/history/history-dashboard.tsx
+++ b/src/widgets/history/history-dashboard.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import type { BodyLanguageData, DashboardAnalytics } from "@/entities/analytics";
-import { Button } from "@/shared/ui";
-import { cn } from "@/shared/lib/cn";
 import { motion } from "motion/react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { BodyLanguagePanelInner } from "@/widgets/history/body-language-panel";
-import { FillerHeatmapInner } from "@/widgets/history/filler-heatmap";
+import type {
+  BodyLanguageData,
+  DashboardAnalytics,
+} from "@/entities/analytics";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui";
 import { ActionTrackerInner } from "@/widgets/history/action-tracker";
 import { AiRecommendationCardInner } from "@/widgets/history/ai-recommendation-card";
+import { BodyLanguagePanelInner } from "@/widgets/history/body-language-panel";
+import { FillerHeatmapInner } from "@/widgets/history/filler-heatmap";
 
 const ScoreTrendChart = dynamic(
   () =>

--- a/src/widgets/history/score-trend-chart.tsx
+++ b/src/widgets/history/score-trend-chart.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import type { ScoreTrendPoint } from "@/entities/analytics";
 import {
-  LineChart,
   Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
-  Tooltip,
-  ResponsiveContainer,
 } from "recharts";
+import type { ScoreTrendPoint } from "@/entities/analytics";
 
 interface ScoreTrendChartProps {
   data: ScoreTrendPoint[];

--- a/src/widgets/history/star-radar-chart.tsx
+++ b/src/widgets/history/star-radar-chart.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { StarRadarData } from "@/entities/analytics";
 import {
   PolarAngleAxis,
   PolarGrid,
@@ -10,6 +9,7 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from "recharts";
+import type { StarRadarData } from "@/entities/analytics";
 
 interface StarRadarChartProps {
   data: StarRadarData;
@@ -33,7 +33,10 @@ function StarRadarChartInner({ data }: StarRadarChartProps) {
     <div className="rounded-xl bg-card border border-white/[0.1] p-6">
       <h3 className="text-base font-semibold mb-4">STAR 충족률</h3>
       <ResponsiveContainer width="100%" height={260}>
-        <RadarChart data={data} margin={{ top: 10, right: 30, bottom: 10, left: 30 }}>
+        <RadarChart
+          data={data}
+          margin={{ top: 10, right: 30, bottom: 10, left: 30 }}
+        >
           <PolarGrid stroke="rgba(255,255,255,0.1)" />
           <PolarAngleAxis
             dataKey="subject"

--- a/src/widgets/history/type-comparison-chart.tsx
+++ b/src/widgets/history/type-comparison-chart.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { TypeComparisonGroup } from "@/entities/analytics";
 import {
   Bar,
   BarChart,
@@ -9,6 +8,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import type { TypeComparisonGroup } from "@/entities/analytics";
 
 interface TypeComparisonChartProps {
   data: TypeComparisonGroup[];

--- a/src/widgets/interview/error-overlay.tsx
+++ b/src/widgets/interview/error-overlay.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { motion } from "motion/react";
 import { useSessionStore } from "@/entities/session";
 import { Button } from "@/shared/ui";
-import { motion } from "motion/react";
 
 interface ErrorOverlayProps {
   onRetry: () => void;

--- a/src/widgets/interview/interview-screen.tsx
+++ b/src/widgets/interview/interview-screen.tsx
@@ -144,8 +144,9 @@ export function InterviewScreen({
       try {
         return await navigator.mediaDevices.getUserMedia(preferred);
       } catch (err) {
-        const mediaError = err as DOMException;
-        if (mediaError?.name !== "NotFoundError") throw err;
+        if (!(err instanceof DOMException) || err.name !== "NotFoundError") {
+          throw err;
+        }
 
         // 일부 환경에서는 카메라가 잠시 사라져도 오디오는 사용 가능하므로 폴백한다.
         return navigator.mediaDevices.getUserMedia({
@@ -206,9 +207,9 @@ export function InterviewScreen({
         }
         startRecording(stream);
       } catch (err) {
-        const mediaError = err as DOMException;
-        const code = mediaError?.name ?? "unknown";
-        const message = mediaError?.message ?? "unknown error";
+        const isDom = err instanceof DOMException;
+        const code = isDom ? err.name : "unknown";
+        const message = isDom ? err.message : "unknown error";
         console.error(`camera/mic init failed: ${code} - ${message}`);
 
         if (
@@ -595,11 +596,13 @@ export function InterviewScreen({
           {/* question/caption overlay — bottom of video */}
           <div className="absolute bottom-0 inset-x-0 pointer-events-none">
             <div className="bg-gradient-to-t from-background via-background/60 to-transparent pt-20 pb-6 px-6">
-              {pinQuestion && currentQuestion && (phase === "speaking" || phase === "listening") && (
-                <p className="text-foreground/50 text-center text-sm max-w-2xl mx-auto mb-2">
-                  {currentQuestion}
-                </p>
-              )}
+              {pinQuestion &&
+                currentQuestion &&
+                (phase === "speaking" || phase === "listening") && (
+                  <p className="text-foreground/50 text-center text-sm max-w-2xl mx-auto mb-2">
+                    {currentQuestion}
+                  </p>
+                )}
               <AnimatePresence mode="wait">
                 {liveCaption && phase === "listening" ? (
                   <motion.p
@@ -612,7 +615,8 @@ export function InterviewScreen({
                     {liveCaption}
                   </motion.p>
                 ) : currentQuestion &&
-                  ((phase === "speaking" && avatarIsSpeaking) || (phase === "listening" && !pinQuestion)) ? (
+                  ((phase === "speaking" && avatarIsSpeaking) ||
+                    (phase === "listening" && !pinQuestion)) ? (
                   <motion.p
                     key={currentQuestion}
                     initial={{ opacity: 0 }}

--- a/src/widgets/landing/landing-hero.tsx
+++ b/src/widgets/landing/landing-hero.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Button } from "@/shared/ui";
-import { signIn, useSession } from "next-auth/react";
-import Link from "next/link";
 import { motion } from "motion/react";
+import Link from "next/link";
+import { signIn, useSession } from "next-auth/react";
+import { Button } from "@/shared/ui";
 
 const features = [
   { emoji: "🧠", category: "면접", title: "산업심리학 기반 구조화 면접" },

--- a/src/widgets/nav/nav-bar.tsx
+++ b/src/widgets/nav/nav-bar.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { cn } from "@/shared/lib/cn";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { signIn, signOut, useSession } from "next-auth/react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/shared/lib/cn";
 
 const links = [
   { href: "/interview", label: "면접" },

--- a/src/widgets/report/report-view.tsx
+++ b/src/widgets/report/report-view.tsx
@@ -223,7 +223,11 @@ export function ReportView({
             <h2 className="text-lg font-semibold mb-6">질문별 분석</h2>
             <div className="space-y-8">
               {feedback.questionAnalyses.map((qa, i) => (
-                <QuestionItem key={`${i}-${qa.questionId}`} qa={qa} sessionId={sessionId} />
+                <QuestionItem
+                  key={`${i}-${qa.questionId}`}
+                  qa={qa}
+                  sessionId={sessionId}
+                />
               ))}
             </div>
           </div>

--- a/tests/compute-analytics.test.ts
+++ b/tests/compute-analytics.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import { computeAnalytics } from "@/features/analytics/compute-analytics";
+
+const baseFeedback = (questionAnalyses: unknown[] = [], extra = {}) => ({
+  deliveryScore: 80,
+  contentScore: 70,
+  summary: "good",
+  growthComparison: null,
+  keyMoments: [],
+  actionItems: [],
+  nextSessionSuggestion: "",
+  questionAnalyses,
+  ...extra,
+});
+
+describe("computeAnalytics", () => {
+  it("returns empty analytics for no sessions", () => {
+    const a = computeAnalytics([], []);
+    expect(a.scoreTrends).toEqual([]);
+    expect(a.typeComparison).toEqual([]);
+    expect(a.stats.totalSessions).toBe(0);
+    expect(a.starRadar).toEqual([]);
+    expect(a.fillerHeatmap.sessions).toEqual([]);
+    expect(a.actionTracker.items).toEqual([]);
+    expect(a.aiRecommendation.suggestion).toBe("");
+  });
+
+  it("orders score trends ascending by createdAt", () => {
+    const sessions = [
+      {
+        id: "b",
+        interviewType: "personality",
+        deliveryScore: 90,
+        contentScore: 80,
+        createdAt: "2026-03-02T00:00:00.000Z",
+      },
+      {
+        id: "a",
+        interviewType: "personality",
+        deliveryScore: 70,
+        contentScore: 60,
+        createdAt: "2026-03-01T00:00:00.000Z",
+      },
+    ];
+    const a = computeAnalytics(sessions, []);
+    expect(a.scoreTrends.map((p) => p.sessionId)).toEqual(["a", "b"]);
+  });
+
+  it("groups type comparison and orders 인성 → 기술 → 컬처핏", () => {
+    const sessions = [
+      {
+        id: "1",
+        interviewType: "culture-fit",
+        deliveryScore: 80,
+        contentScore: 80,
+        createdAt: "2026-03-01T00:00:00.000Z",
+      },
+      {
+        id: "2",
+        interviewType: "personality",
+        deliveryScore: 60,
+        contentScore: 70,
+        createdAt: "2026-03-01T00:00:00.000Z",
+      },
+      {
+        id: "3",
+        interviewType: "technical",
+        deliveryScore: 90,
+        contentScore: 50,
+        createdAt: "2026-03-01T00:00:00.000Z",
+      },
+    ];
+    const a = computeAnalytics(sessions, []);
+    expect(a.typeComparison.map((g) => g.type)).toEqual([
+      "personality",
+      "technical",
+      "culture-fit",
+    ]);
+    expect(
+      a.typeComparison.find((g) => g.type === "personality"),
+    ).toMatchObject({
+      typeLabel: "인성",
+      avgDelivery: 60,
+      avgContent: 70,
+      count: 1,
+    });
+  });
+
+  it("computes change rate from first to latest completed session", () => {
+    const sessions = [
+      {
+        id: "1",
+        interviewType: "personality",
+        deliveryScore: 50,
+        contentScore: 50,
+        createdAt: "2026-03-01T00:00:00.000Z",
+      },
+      {
+        id: "2",
+        interviewType: "personality",
+        deliveryScore: 80,
+        contentScore: 70,
+        createdAt: "2026-03-05T00:00:00.000Z",
+      },
+    ];
+    const a = computeAnalytics(sessions, []);
+    expect(a.stats.changeRate).toEqual({
+      deliveryChange: 30,
+      contentChange: 20,
+      hasEnoughData: true,
+    });
+  });
+
+  it("flags repeat action items by word overlap", () => {
+    const sessions = [
+      {
+        id: "old",
+        interviewType: "personality",
+        deliveryScore: null,
+        contentScore: null,
+        createdAt: "2026-03-01T00:00:00.000Z",
+      },
+      {
+        id: "new",
+        interviewType: "personality",
+        deliveryScore: null,
+        contentScore: null,
+        createdAt: "2026-03-05T00:00:00.000Z",
+      },
+    ];
+    const feedback = [
+      {
+        sessionId: "old",
+        summaryJson: baseFeedback([], {
+          actionItems: [{ id: 1, text: "구체적 사례를 더 추가" }],
+        }),
+      },
+      {
+        sessionId: "new",
+        summaryJson: baseFeedback([], {
+          actionItems: [
+            { id: 1, text: "구체적 사례를 더 추가하기" },
+            { id: 2, text: "처음 보는 액션" },
+          ],
+        }),
+      },
+    ];
+    const a = computeAnalytics(sessions, feedback);
+    expect(a.actionTracker.items.map((i) => i.tag)).toEqual(["repeat", "new"]);
+  });
+
+  it("aggregates STAR radar percentages across all question analyses", () => {
+    const sessions = [
+      {
+        id: "1",
+        interviewType: "personality",
+        deliveryScore: 80,
+        contentScore: 70,
+        createdAt: "2026-03-01T00:00:00.000Z",
+      },
+    ];
+    const feedback = [
+      {
+        sessionId: "1",
+        summaryJson: baseFeedback([
+          {
+            questionId: 1,
+            questionText: "q",
+            answer: "a",
+            starFulfillment: {
+              situation: true,
+              task: false,
+              action: true,
+              result: false,
+            },
+            fillerWords: [],
+            durationSec: 30,
+            contentScore: 70,
+            feedback: "ok",
+          },
+          {
+            questionId: 2,
+            questionText: "q",
+            answer: "a",
+            starFulfillment: {
+              situation: true,
+              task: true,
+              action: false,
+              result: false,
+            },
+            fillerWords: [],
+            durationSec: 30,
+            contentScore: 70,
+            feedback: "ok",
+          },
+        ]),
+      },
+    ];
+    const a = computeAnalytics(sessions, feedback);
+    const map = new Map(a.starRadar.map((p) => [p.subject, p.value]));
+    expect(map.get("Situation")).toBe(100);
+    expect(map.get("Task")).toBe(50);
+    expect(map.get("Action")).toBe(50);
+    expect(map.get("Result")).toBe(0);
+  });
+});

--- a/tests/intervention-engine.test.ts
+++ b/tests/intervention-engine.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { MetricSnapshot } from "@/entities/metrics";
+import { createInterventionEngine } from "@/features/voice-coach/intervention-engine";
+
+function snapshot(
+  timestampSec: number,
+  overrides: Partial<{
+    gazeFront: boolean;
+    upright: boolean;
+    positive: boolean;
+    moderate: boolean;
+    yaw: number;
+    pitch: number;
+    shoulderTilt: number;
+    headOffset: number;
+    frown: number;
+    wrist: number;
+  }> = {},
+): MetricSnapshot {
+  return {
+    timestamp: timestampSec * 1000,
+    gaze: {
+      pitch: overrides.pitch ?? 0,
+      yaw: overrides.yaw ?? 0,
+      isFrontFacing: overrides.gazeFront ?? true,
+    },
+    posture: {
+      shoulderTilt: overrides.shoulderTilt ?? 0,
+      headOffset: overrides.headOffset ?? 0,
+      isUpright: overrides.upright ?? true,
+    },
+    expression: {
+      frownScore: overrides.frown ?? 0,
+      isPositiveOrNeutral: overrides.positive ?? true,
+    },
+    gesture: {
+      wristMovement: overrides.wrist ?? 0,
+      isModerate: overrides.moderate ?? true,
+    },
+  };
+}
+
+describe("createInterventionEngine", () => {
+  const cfg = { cooldown: 20, minInterval: 20, triggerDuration: 5 };
+
+  it("never fires while user is speaking", () => {
+    const engine = createInterventionEngine(cfg);
+    for (let t = 21; t < 40; t++) {
+      const r = engine.evaluate(snapshot(t, { upright: false }), true);
+      expect(r).toBeNull();
+    }
+  });
+
+  it("fires after sustained issue beyond triggerDuration", () => {
+    const engine = createInterventionEngine(cfg);
+    // first eval starts the timer at t=21 (past minInterval)
+    expect(
+      engine.evaluate(snapshot(21, { upright: false, shoulderTilt: 5 }), false),
+    ).toBeNull();
+    // still under triggerDuration
+    expect(
+      engine.evaluate(snapshot(24, { upright: false, shoulderTilt: 5 }), false),
+    ).toBeNull();
+    // crossed triggerDuration
+    const fired = engine.evaluate(
+      snapshot(27, { upright: false, shoulderTilt: 5 }),
+      false,
+    );
+    expect(fired?.type).toBe("posture");
+  });
+
+  it("respects cooldown after firing", () => {
+    const engine = createInterventionEngine(cfg);
+    engine.evaluate(snapshot(21, { upright: false }), false);
+    engine.evaluate(snapshot(27, { upright: false }), false); // fires
+    // 10s later — still in cooldown
+    const r = engine.evaluate(snapshot(37, { upright: false }), false);
+    expect(r).toBeNull();
+  });
+
+  it("picks the highest severity issue when multiple", () => {
+    const engine = createInterventionEngine(cfg);
+    // sustain both posture (severity 1) and gaze (severity 100) for 6s
+    engine.evaluate(
+      snapshot(21, { upright: false, gazeFront: false, yaw: 50, pitch: 50 }),
+      false,
+    );
+    const fired = engine.evaluate(
+      snapshot(27, { upright: false, gazeFront: false, yaw: 50, pitch: 50 }),
+      false,
+    );
+    expect(fired?.type).toBe("gaze");
+  });
+
+  it("clears the issue start when condition recovers", () => {
+    const engine = createInterventionEngine(cfg);
+    engine.evaluate(snapshot(21, { upright: false }), false);
+    // recovers
+    engine.evaluate(snapshot(23, { upright: true }), false);
+    // re-enters bad state — must restart trigger window, not fire immediately
+    expect(
+      engine.evaluate(snapshot(25, { upright: false, shoulderTilt: 5 }), false),
+    ).toBeNull();
+  });
+});

--- a/tests/rate-limit.test.ts
+++ b/tests/rate-limit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { rateLimit } from "@/shared/lib/rate-limit";
+
+describe("rateLimit", () => {
+  it("allows requests under the limit", () => {
+    const check = rateLimit({ windowMs: 1000, max: 3 });
+    expect(check("u1", "r")).toBeNull();
+    expect(check("u1", "r")).toBeNull();
+    expect(check("u1", "r")).toBeNull();
+  });
+
+  it("rejects when the limit is exceeded", () => {
+    const check = rateLimit({ windowMs: 1000, max: 2 });
+    expect(check("u2", "r")).toBeNull();
+    expect(check("u2", "r")).toBeNull();
+    const blocked = check("u2", "r");
+    expect(blocked).not.toBeNull();
+    expect(blocked?.status).toBe(429);
+  });
+
+  it("isolates buckets per user", () => {
+    const check = rateLimit({ windowMs: 1000, max: 1 });
+    expect(check("u3", "r")).toBeNull();
+    expect(check("u4", "r")).toBeNull();
+    expect(check("u3", "r")?.status).toBe(429);
+  });
+
+  it("isolates buckets per route key", () => {
+    const check = rateLimit({ windowMs: 1000, max: 1 });
+    expect(check("u5", "alpha")).toBeNull();
+    expect(check("u5", "beta")).toBeNull();
+    expect(check("u5", "alpha")?.status).toBe(429);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- **Security**: extend proxy matcher to `/dashboard/*` and `/drill/*`; apply rate limit to `/api/profile`, `/api/sessions`, `/api/sessions/[id]/feedback`, `/api/sessions/[id]/drill`; replace `interviewType`/`mode` `z.string()` with shared zod enums in three API routes
- **Correctness**: replace `as DOMException` with `instanceof DOMException` in interview/drill media init paths
- **Performance**: index feedback rows by `sessionId` once in `computeAnalytics`, threading the Map through filler heatmap, action tracker, and AI recommendation builders (was O(N×M) `Array.find` per session)
- **DB**: `sessions(user_id, created_at)`, `questions(session_id)`, `metric_snapshots(session_id)`, `accounts(user_id)` indexes via new drizzle migration `0003_woozy_captain_britain.sql`. `postgres-js` pool now sets `max`, `idle_timeout`, `connect_timeout`, `prepare=false` (env-overridable via `DATABASE_POOL_MAX`)
- **Tests**: vitest + 15 unit tests for `compute-analytics`, `intervention-engine`, `rate-limit`. `pnpm test` / `pnpm test:watch` scripts added

## Test plan

- [x] `pnpm test` — 15/15 passing
- [x] `pnpm build` — production build succeeds, all routes compile
- [x] `pnpm lint` — 29 pre-existing diagnostics (all present on `main`); no new failures introduced (baseline 70 errors → 29 after formatter pass)
- [ ] manual: hit each rate-limited endpoint to verify 429 emits at the documented threshold
- [ ] **deploy step**: run `pnpm db:migrate` after merge — adds the new indexes (CREATE INDEX is non-blocking but write throughput briefly affected on large tables)

## Out of scope (follow-up PRs)

- `interview-screen.tsx` (908 LOC) split into `use-media-stream` / `use-interview-loop` hooks + `landmarks-canvas` / `interview-controls` components
- `resumeFileId` ownership check (would need an OpenAI file tracking table)
- in-memory rate limit → Upstash/Redis for serverless multi-instance
- a11y / `useExhaustiveDependencies` cleanup (29 pre-existing diagnostics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)