### PR TITLE
style: hide page scrollbar globally

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,6 +40,15 @@ body {
   font-family: var(--font-sans);
 }
 
+html {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+html::-webkit-scrollbar {
+  display: none;
+}
+
 .gradient-text {
   background: linear-gradient(
     135deg,


### PR DESCRIPTION
## Summary
- Hide vertical page scrollbar across browsers (Webkit, Firefox, IE/Edge) on the `html` element while keeping scroll behavior intact.

## Test plan
- [ ] Open landing page; confirm right-side scrollbar is no longer visible
- [ ] Verify scrolling still works via mouse wheel and touchpad
- [ ] Check Safari, Chrome, and Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)